### PR TITLE
fix: set flatModuleId to the name from package.json

### DIFF
--- a/lib/model/ng-package.ts
+++ b/lib/model/ng-package.ts
@@ -40,15 +40,13 @@ export class NgPackage {
   }
 
   /** Package meta information */
-  public get meta() {
+  public get meta(): { name: string, scope?: string } {
     // split into name and scope (`@<scope>/<name>`)
     let scope: string, name: string = `${this.packageJson.name}`;
-    if (name.startsWith(SCOPE_PREFIX)) {
+    if (name.startsWith(SCOPE_PREFIX) && name.indexOf(SCOPE_NAME_SEPARATOR) > 0) {
       const idx = name.indexOf(SCOPE_NAME_SEPARATOR);
       scope = name.substring(0, idx);
       name = name.substring(idx + 1);
-    } else {
-      scope = this.packageJson.name;
     }
 
     return { name, scope };

--- a/lib/steps/ngc.ts
+++ b/lib/steps/ngc.ts
@@ -11,7 +11,7 @@ export const prepareTsConfig = (ngPkg: NgPackage, outFile: string): Promise<stri
   return readJson(path.resolve(__dirname, '..', 'conf', 'tsconfig.ngc.json'))
     .then((tsConfig: any) => {
 
-      tsConfig['angularCompilerOptions']['flatModuleId'] = ngPkg.flatModuleFileName;
+      tsConfig['angularCompilerOptions']['flatModuleId'] = ngPkg.packageJson.name;
       tsConfig['angularCompilerOptions']['flatModuleOutFile'] = `${ngPkg.flatModuleFileName}.js`;
 
       tsConfig['files'] = [ ngPkg.ngPackageJson.lib.entryFile ];


### PR DESCRIPTION
Fixes an AoT import error when metadata.json files include an "importAs" property.