### PR TITLE
fix: add `rxjs/ReplaySubject` to rollup defaults

### DIFF
--- a/integration/sample_core/src/angular.service.ts
+++ b/integration/sample_core/src/angular.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from "@angular/core";
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 import 'rxjs/add/operator/map';
 
 @Injectable()
 export class AngularService {
+  
+  private _subject: Subject<any> = new ReplaySubject<any>(1);
 
   constructor(
     private http: Http
@@ -14,6 +18,10 @@ export class AngularService {
 
     return this.http.get('/foo/bar')
       .map((res: Response) => `${res.ok}`);
+  }
+
+  public get bar(): Observable<any> {
+    return this._subject.asObservable();
   }
 
 }

--- a/lib/steps/rollup.ts
+++ b/lib/steps/rollup.ts
@@ -34,6 +34,7 @@ export const rollup = (opts: RollupOptions) => {
     'rxjs/ObservableInput':       'Rx',
     'rxjs/Observable':            'Rx',
     'rxjs/Observer':              'Rx',
+    'rxjs/ReplaySubject':         'Rx',
     'rxjs/Scheduler':             'Rx',
     'rxjs/Subject':               'Rx',
     'rxjs/SubjectSubscriber':     'Rx',


### PR DESCRIPTION
Fixes the following BUILD ERROR
'ReplaySubject' is not exported by node_modules\rxjs\ReplaySubject.js
Error: 'ReplaySubject' is not exported by node_modules\rxjs\ReplaySubject.js