### PR TITLE
removed node_modules, excluded typings

### DIFF
--- a/lib/steps/assets.ts
+++ b/lib/steps/assets.ts
@@ -26,7 +26,7 @@ export const processAssets = (src: string, dest: string): Promise<any> => {
   return new Promise((resolve, reject) => {
     debug(`processAssets ${src} to ${dest}`);
 
-    vfs.src(`${src}/**/*.ts`)
+    vfs.src([`${src}/**/*.ts`, '!node_modules/**/*', '!**/*.d.ts'])
       .pipe(inlineNg2Template({
         base: `${src}`,
         useRelativePaths: true,

--- a/lib/steps/assets.ts
+++ b/lib/steps/assets.ts
@@ -26,7 +26,7 @@ export const processAssets = (src: string, dest: string): Promise<any> => {
   return new Promise((resolve, reject) => {
     debug(`processAssets ${src} to ${dest}`);
 
-    vfs.src([`${src}/**/*.ts`, '!node_modules/**/*', '!**/*.d.ts'])
+    vfs.src([`${src}/**/*.ts`, '!node_modules/**/*'])
       .pipe(inlineNg2Template({
         base: `${src}`,
         useRelativePaths: true,


### PR DESCRIPTION
As mentioned in #51 by @ChrisProlls in his [comment](https://github.com/dherges/ng-packagr/issues/51#issuecomment-307148324), we're unable to specify a source folder apart from the package.json file.
So we have to exclude the node_modules folder and the typings from the template glob.