### PR TITLE
test: library w/ custom typings

### DIFF
--- a/integration/build.js
+++ b/integration/build.js
@@ -5,6 +5,7 @@ const SAMPLES = [
   path.resolve(__dirname, 'sample_core', 'ng-package.json'),
   path.resolve(__dirname, 'sample_custom', 'ng-package.json'),
   path.resolve(__dirname, 'sample_material', 'ng-package.json'),
+  path.resolve(__dirname, 'sample_typings', 'ng-package.json'),
 ];
 
 /*

--- a/integration/sample_typings/ng-package.json
+++ b/integration/sample_typings/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../lib/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public_api.ts"
+  }
+}

--- a/integration/sample_typings/package.json
+++ b/integration/sample_typings/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sample-typings",
+  "description": "A sample library with custom type definitions",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "validate-commit-msg": "2.12.2"
+  }
+}

--- a/integration/sample_typings/public_api.ts
+++ b/integration/sample_typings/public_api.ts
@@ -1,0 +1,1 @@
+export * from './src/validator';

--- a/integration/sample_typings/src/validate-commit-msg.d.ts
+++ b/integration/sample_typings/src/validate-commit-msg.d.ts
@@ -1,0 +1,4 @@
+declare module 'validate-commit-msg' {
+
+  export function validate(msg: string): boolean;
+}

--- a/integration/sample_typings/src/validator.ts
+++ b/integration/sample_typings/src/validator.ts
@@ -1,0 +1,4 @@
+/// <reference path="./validate-commit-msg.d.ts" />
+import { validate } from 'validate-commit-msg';
+
+export const result: boolean = validate("foobar");

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "rxjs": "^5.4.0",
     "sinon": "^2.3.2",
     "standard-version": "^4.0.0",
+    "validate-commit-msg": "^2.12.2",
     "zone.js": "^0.8.10"
   },
   "private": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "experimentalDecorators": true,
+    "target": "es5",
     "lib": [
       "es2015",
       "es2016"


### PR DESCRIPTION
Motivation: sometimes, we have 3rd party dependencies that ship w/o type definitions. Maybe, we don't have type definitions at DefinetlyTyped and so we have to write our own. Since ng-packagr auto-generates our tsconfig, we have to import custom type definitions via triple-slash reference.

This change adds a sample library to the integration tests, making this a legimitate and desired feature which needs to be supported.