### PR TITLE
Feature/scss node modules import

### DIFF
--- a/integration/sample_material/baz/baz.component.html
+++ b/integration/sample_material/baz/baz.component.html
@@ -1,0 +1,1 @@
+<h1 class="baz">baz!</h1>

--- a/integration/sample_material/baz/baz.component.scss
+++ b/integration/sample_material/baz/baz.component.scss
@@ -1,5 +1,5 @@
 @import '~node-sass/test/fixtures/include-files/file-not-processed-by-loader';
 
 .baz {
-    background-color: $variable-defined-by-file-not-processed-by-loader;
+    color: $variable-defined-by-file-not-processed-by-loader;
 }

--- a/integration/sample_material/baz/baz.component.scss
+++ b/integration/sample_material/baz/baz.component.scss
@@ -1,0 +1,5 @@
+@import '~node-sass/test/fixtures/include-files/file-not-processed-by-loader';
+
+.baz {
+    background-color: $variable-defined-by-file-not-processed-by-loader;
+}

--- a/integration/sample_material/baz/baz.component.ts
+++ b/integration/sample_material/baz/baz.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'baz-component',
+  templateUrl: './baz.component.html',
+  styleUrls: ['./baz.component.scss']
+})
+export class BazComponent {
+}

--- a/integration/sample_material/public_api.ts
+++ b/integration/sample_material/public_api.ts
@@ -1,3 +1,4 @@
 export * from './bar/bar.component';
 export * from './foo/foo.component';
+export * from './baz/baz.component';
 export * from './ui-lib.module';

--- a/integration/sample_material/specs/assets.ts
+++ b/integration/sample_material/specs/assets.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/material`, () => {
+
+  describe(`material.umd.js`, () => {
+    let GENERATED;
+    before(() => {
+      GENERATED = require(path.resolve(__dirname, '..', 'dist', 'bundles', 'material.umd.js'));
+    });
+
+    it(`should exist`, () => {
+      expect(GENERATED.BazComponent).to.be.ok;
+    });
+
+    it(`should have "BazComponent"`, () => {
+      expect(GENERATED).to.be.ok;
+    });
+
+    it(`should have "BazComponent.decorators"`, () => {
+      expect(GENERATED.BazComponent.decorators).to.be.ok;
+    });
+
+    it(`should have styles for "BazComponent"`, () => {
+      expect(GENERATED.BazComponent.decorators[0].args[0].styles).to.be.ok;
+    });
+
+    it(`should have style with: "color: red"`, () => {
+      expect(GENERATED.BazComponent.decorators[0].args[0].styles[0]).to.have.string('color: "red"');
+    });
+
+  });
+});

--- a/integration/sample_material/ui-lib.module.ts
+++ b/integration/sample_material/ui-lib.module.ts
@@ -2,17 +2,20 @@ import { NgModule } from '@angular/core';
 import { FooComponent } from './foo/foo.component';
 import { BarComponent } from './bar/bar.component';
 import { FooBarComponent } from './foo-bar/foo-bar.component';
+import { BazComponent } from './baz/baz.component';
 
 @NgModule({
   declarations: [
     FooComponent,
     BarComponent,
     FooBarComponent,
+    BazComponent,
   ],
   exports: [
     FooComponent,
     BarComponent,
     FooBarComponent,
+    BazComponent,
   ]
 })
 export class UiLibModule {}

--- a/lib/steps/assets.ts
+++ b/lib/steps/assets.ts
@@ -60,6 +60,15 @@ export const processAssets = (src: string, dest: string): Promise<any> => {
 }
 
 
+const sassImporter = (url: string): any => {
+  if (url[0] === '~') {
+    url = path.resolve('node_modules', url.substr(1));
+  }
+
+  return { file: url };
+}
+
+
 const pickRenderer = (filePath: string, ext: string[], file: string): Promise<string> => {
 
   switch (path.extname(filePath)) {
@@ -67,7 +76,7 @@ const pickRenderer = (filePath: string, ext: string[], file: string): Promise<st
     case '.scss':
     case '.sass':
       debug(`rendering sass for ${filePath}`);
-      return renderSass({ file: filePath });
+      return renderSass({ file: filePath, importer: sassImporter });
 
     case '.css':
     default:


### PR DESCRIPTION
As described in #66 usages of tilde `~` in scss imports are dissolved to `node_modules`.