### PR TITLE
fix: pass file pathes to `postcss.process()`

### DIFF
--- a/lib/steps/assets.ts
+++ b/lib/steps/assets.ts
@@ -6,7 +6,8 @@ const inlineNg2Template =  require('gulp-inline-ng2-template');
 
 const autoprefixer = require('autoprefixer');
 const browserslist = require('browserslist');
-const postcss      = require('postcss');
+//const postcss      = require('postcss');
+import postcss = require('postcss');
 const sass         = require('node-sass');
 
 import { debug, warn } from '../util/log';
@@ -37,8 +38,13 @@ export const processAssets = (src: string, dest: string): Promise<any> => {
 
           debug(`postcss with autoprefixer for ${path}`);
           const browsers = browserslist(undefined, { path });
-          render.then((css: string) => postcss([ autoprefixer({ browsers }) ]).process(css))
-            .then((result) => {
+
+          render
+            .then((css: string) => {
+              return postcss([ autoprefixer({ browsers }) ])
+                .process(css, { from: path, to: path.replace(ext, '.css') });
+            })
+            .then((result: postcss.Result) => {
 
               result.warnings().forEach((msg) => {
                 warn(msg.toString());


### PR DESCRIPTION
Motivation: In certain use cases, autoprefixer and browserslist ended up looking up an `undefined` path since postcss explicitly sets plugin options, thus overwriting a file path to `undefined`.

[debug] processAssets ng-packaged/my-lib to ng-packaged/.ng_build/ts
[debug] render stylesheet ng-packaged/my-lib/src/foo/foo.component.scss
[debug] rendering sass for ng-packaged/my-lib/src/foo/foo.component.scss
[debug] postcss with autoprefixer for ng-packaged/my-lib/src/foo/foo.component.scss

BUILD ERROR
Path must be a string. Received undefined
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.resolve (path.js:1146:7)
    at eachParent (ng-packaged/node_modules/ng-packagr/node_modules/browserslist/index.js:65:18)
    at getStat (ng-packaged/node_modules/ng-packagr/node_modules/browserslist/index.js:79:12)
    at browserslist (ng-packaged/node_modules/ng-packagr/node_modules/browserslist/index.js:188:15)
    at Browsers.parse (ng-packaged/node_modules/ng-packagr/node_modules/autoprefixer/lib/browsers.js:61:16)
    at new Browsers (ng-packaged/node_modules/ng-packagr/node_modules/autoprefixer/lib/browsers.js:52:30)
    at loadPrefixes (ng-packaged/node_modules/ng-packagr/node_modules/autoprefixer/lib/autoprefixer.js:67:24)
    at plugin (ng-packaged/node_modules/ng-packagr/node_modules/autoprefixer/lib/autoprefixer.js:78:24)
    at LazyResult.run (ng-packaged/node_modules/postcss/lib/lazy-result.js:270:20)