### PR TITLE
Implements reading excludes from project tsconfig

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,20 @@
       "request": "launch",
       "name": "yarn samples:dev",
       "program": "${workspaceRoot}/integration/samples.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug samples:dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "debug:samples:dev"
+      ],
+      "port": 9229,
+      "stopOnEntry": false,
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector"
     }
   ],
   "compounds": []

--- a/integration/samples/core/not-include/simple.ts
+++ b/integration/samples/core/not-include/simple.ts
@@ -1,0 +1,3 @@
+export interface UnusedInterface {
+  test: boolean;
+}

--- a/integration/samples/core/tsconfig.json
+++ b/integration/samples/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "exclude": [
+    "not-include"
+  ]
+}

--- a/integration/samples/typings/tsconfig.json
+++ b/integration/samples/typings/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "include": [
+    "excludes"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "samples:test": "TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --compilers ts:ts-node/register integration/samples/*/specs/**/*.ts",
     "consumer": "integration/consumer.sh",
     "test": "yarn build && yarn samples && yarn samples:test",
+    "debug:samples:dev": "node --inspect integration/samples.js",
     "commitmsg": "validate-commit-msg"
   }
 }

--- a/src/lib/model/ng-package.ts
+++ b/src/lib/model/ng-package.ts
@@ -16,6 +16,10 @@ export class NgPackage {
     public packageJson: any
   ) {}
 
+  public get projectPath(): string {
+    return this.basePath;
+  }
+
   public get dest(): string {
     return path.resolve(this.basePath, this.ngPackageJson.dest);
   }

--- a/src/lib/util/fs.ts
+++ b/src/lib/util/fs.ts
@@ -2,6 +2,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 const read = require('read-file');
 
+export const fileExists = (file: string): boolean => {
+
+  return fs.existsSync(file);
+}
+
 export const readFile = (file: string): Promise<string> => {
 
   return new Promise((resolve, reject) => {

--- a/tsconfig.packagr.json
+++ b/tsconfig.packagr.json
@@ -7,7 +7,12 @@
     "inlineSourceMap": false,
     "inlineSources": true,
     "declaration": true,
-    "lib": ["es2015", "dom"],
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ],
     "outDir": "dist/lib",
     "experimentalDecorators": true,
     "noEmitOnError": true,


### PR DESCRIPTION
## I'm submitting a...
- [x] Feature


## Description
This PR improves the process of build by including some configs from default `tsconfig.json` of the project.
For now I just implemented `exclude` but we may merge any other items.
In some project there are demos or other stuff that should not be included in `dist` folder after building the library. By this feature we can achieve this matter.

I also added a new launch to debug the project easier with the experiment debug feature of chrome.
Did some cleaning up and stuff that they're not really worth mentioning.

## Does this PR introduce a breaking change?

- [x] No
