### PR TITLE
fix(#126): Properly handle rejected promises in utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# IDE temp data
+/.vs
+/.idea
+
 # Runtime data
 pids
 *.pid

--- a/src/lib/util/copy.ts
+++ b/src/lib/util/copy.ts
@@ -1,27 +1,14 @@
+import { promisify } from './promisify';
 const cpx = require('cpx');
 
-export const copyFiles = (src: string, dest: string, options?: any): Promise<any> => {
+export const copyFiles = (src: string, dest: string, options?: any): Promise<void> => {
 
-  return new Promise((resolve, reject) => {
-
+  return promisify<void>((resolveOrReject) => {
     if (options) {
-      cpx.copy(src, dest, options, (err) => {
-        if (err) {
-          reject();
-        }
-
-        resolve();
-      });
+      cpx.copy(src, dest, options, resolveOrReject);
     } else {
-      cpx.copy(src, dest, (err) => {
-        if (err) {
-          reject();
-        }
-
-        resolve();
-      });
+      cpx.copy(src, dest, resolveOrReject);
     }
-
   });
 
-}
+};

--- a/src/lib/util/fs.ts
+++ b/src/lib/util/fs.ts
@@ -4,27 +4,31 @@ const read = require('read-file');
 
 export const readFile = (file: string): Promise<string> => {
 
-  return new Promise((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
 
-    read(file, { encoding: 'utf8', normalize: true }, (err, buffer: Buffer) => {
+    const fileReadOptions = {
+      encoding: 'utf8',
+      normalize: true
+    };
+    read(file, fileReadOptions, (err, buffer?: Buffer) => {
       if (err) {
         reject(err);
+      } else {
+        resolve(buffer!.toString());
       }
-
-      resolve(buffer.toString());
     });
   });
 };
 
-export const writeFile = (file: string, content: any): Promise<any> => {
+export const writeFile = (file: string, content: any): Promise<void> => {
 
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject): void => {
     fs.writeFile(file, content, (err) => {
       if (err) {
         reject(err);
+      } else {
+        resolve();
       }
-
-      resolve();
     });
   });
 };

--- a/src/lib/util/fs.ts
+++ b/src/lib/util/fs.ts
@@ -1,36 +1,32 @@
 import * as fs from 'fs';
 import * as path from 'path';
 const read = require('read-file');
+import { promisify } from './promisify';
 
 export const readFile = (file: string): Promise<string> => {
 
-  return new Promise<string>((resolve, reject) => {
-
+  return promisify<string>((resolveOrReject) => {
     const fileReadOptions = {
       encoding: 'utf8',
       normalize: true
     };
     read(file, fileReadOptions, (err, buffer?: Buffer) => {
-      if (err) {
-        reject(err);
+      if (buffer) {
+        resolveOrReject(err, buffer.toString());
       } else {
-        resolve(buffer!.toString());
+        resolveOrReject(err);
       }
     });
   });
+
 };
 
-export const writeFile = (file: string, content: any): Promise<void> => {
+export const writeFile = (file: string, content: any): Promise<string> => {
 
-  return new Promise<void>((resolve, reject): void => {
-    fs.writeFile(file, content, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
+  return promisify<string>((resolveOrReject) => {
+    fs.writeFile(file, content, resolveOrReject);
   });
+
 };
 
 

--- a/src/lib/util/promisify.ts
+++ b/src/lib/util/promisify.ts
@@ -1,0 +1,14 @@
+
+export type PromiseCallback<T> = (err: Error, value?: T) => void;
+
+export function promisify<T>(resolver: (resolveOrReject: PromiseCallback<T>) => void): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    resolver(((err: Error, value?: T): void => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(value);
+      }
+    }))
+  });
+}

--- a/src/lib/util/rimraf.ts
+++ b/src/lib/util/rimraf.ts
@@ -1,29 +1,16 @@
 const rm = require('rimraf');
-import { debug } from '../util/log';
+import { promisify } from './promisify';
+import { debug } from './log';
 
 export const rimraf = (f: any, opts?: any) => {
+  debug(`rimraf ${f}`);
 
-  return new Promise((resolve, reject) => {
-    debug(`rimraf ${f}`);
-
+  return promisify<void>((resolveOrReject) => {
     if (opts) {
-      rm(f, opts, (err) => {
-        if (err) {
-          reject(err);
-        }
-
-        resolve();
-      });
+      rm(f, opts, resolveOrReject);
     } else {
-      rm(f, (err) => {
-        if (err) {
-          reject(err);
-        }
-
-        resolve();
-      });
+      rm(f, resolveOrReject);
     }
-
   });
 
-}
+};


### PR DESCRIPTION
## I'm submitting a...

- [x] Bug Fix
- [ ] Feature
- [ ] Other (Refactoring, Added tests, Documentation, ...)


## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern, see current [`.vcmrc`](https://github.com/dherges/ng-packagr/blob/master/.vcmrc)
- Existing tests should cover the changes.


## Description

Fix for #126 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
