### PR TITLE
refactor: extract Angular bundling process

### DIFF
--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -1,0 +1,85 @@
+import { NgEntrypoint, NgArtefacts, NgPackage } from './model/ng-package';
+import { processAssets } from './steps/assets';
+import { prepareTsConfig, ngc } from './steps/ngc';
+import { remapSourcemap } from './steps/sorcery';
+import { rollup } from './steps/rollup';
+import { downlevelWithTsc } from './steps/tsc';
+import { copyFiles } from './util/copy';
+import { modifyJsonFiles } from './util/json';
+
+/**
+ * Main Angular bundling processing.
+ *
+ * @param entry A TypeScript source file (`*.ts`) of the bundle's entrypoint.
+ * @param ngPkg Parent Angular package.
+ * @returns Distribution-ready build artefacts.
+ */
+export const generateNgBundle = (entry: NgEntrypoint, ngPkg: NgPackage): Promise<NgArtefacts> => Promise.resolve()
+  // 1. ASSETS
+  .then(() => processAssets(ngPkg.src, `${ngPkg.workingDirectory}/ts`))
+  // 2. NGC
+  .then(() => prepareTsConfig(ngPkg, `${ngPkg.workingDirectory}/ts/tsconfig.lib.json`)
+    .then((tsConfigFile: string) => ngc(tsConfigFile, `${ngPkg.workingDirectory}/ts`))
+    .then((es2015EntryFile: string) =>
+      // XX: see #46 - ngc only references to closure-annotated ES6 sources
+      remapSourcemap(`${ngPkg.workingDirectory}/ts/${ngPkg.flatModuleFileName}.js`)
+        .then(() => Promise.resolve(es2015EntryFile)))
+  )
+  // 3. FESM15: ROLLUP
+  .then((es2015EntryFile: string) =>
+    rollup({
+      moduleName: ngPkg.meta.name,
+      entry: es2015EntryFile,
+      format: 'es',
+      dest: `${ngPkg.workingDirectory}/${ngPkg.artefacts.es2015}`,
+      externals: ngPkg.libExternals
+    })
+    // XX ... rollup generates relative paths in sourcemaps. It would be nice to re-locate source map files
+    // so that `@scope/name/foo/bar.ts` shows up as path in the browser...
+    .then(() => remapSourcemap(`${ngPkg.workingDirectory}/${ngPkg.artefacts.es2015}`))
+  )
+  // 4. FESM5: TSC
+  .then(() =>
+    downlevelWithTsc(
+      `${ngPkg.workingDirectory}/${ngPkg.artefacts.es2015}`,
+      `${ngPkg.workingDirectory}/${ngPkg.artefacts.module}`)
+    .then(() => remapSourcemap(`${ngPkg.workingDirectory}/${ngPkg.artefacts.module}`))
+  )
+  // 5. UMD: ROLLUP
+  .then(() =>
+    rollup({
+      moduleName: ngPkg.meta.name,
+      entry: `${ngPkg.workingDirectory}/${ngPkg.artefacts.module}`,
+      format: 'umd',
+      dest: `${ngPkg.workingDirectory}/${ngPkg.artefacts.main}`,
+      externals: ngPkg.libExternals
+    })
+    .then(() => remapSourcemap(`${ngPkg.workingDirectory}/${ngPkg.artefacts.main}`))
+  )
+  // 6. COPY FILES
+  .then(() => copyFiles(`${ngPkg.workingDirectory}/${ngPkg.meta.scope}/**/*.{js,js.map}`, `${ngPkg.dest}/${ngPkg.meta.scope}`))
+  .then(() => copyFiles(`${ngPkg.workingDirectory}/bundles/**/*.{js,js.map}`, `${ngPkg.dest}/bundles`))
+  .then(() => copyFiles(`${ngPkg.workingDirectory}/ts/**/*.{d.ts,metadata.json}`, `${ngPkg.dest}`))
+  // 7. SOURCEMAPS: RELOCATE PATHS
+  // XX ... modifyJsonFiles() should maybe called 'relocateSourceMaps()' in 'steps' folder
+  .then(() => modifyJsonFiles(`${ngPkg.dest}/**/*.js.map`, (sourceMap: any): any => {
+    sourceMap['sources'] = sourceMap['sources']
+      .map((path: string): string => path.replace('../ts',
+        ngPkg.meta.scope ? `~/${ngPkg.meta.scope}/${ngPkg.meta.name}` : `~/${ngPkg.meta.name}`));
+
+    return sourceMap;
+  }))
+  // 8. COLLECT GENERATED ARTEFACTS
+  .then(() => {
+
+    return ngPkg.artefacts;
+    /*
+    return {
+      main: '',
+      module: '',
+      es2015: '',
+      typings: '',
+      metadata: ''
+    };
+    */
+  });

--- a/src/lib/model/ng-package.ts
+++ b/src/lib/model/ng-package.ts
@@ -18,13 +18,6 @@ export class NgPackage {
     private $schema: SchemaClass<NgPackageConfig>
   ) {}
 
-  /*
-  const foo = this.$schema.$$get('lib.entryFile'); // --> "src/public_api.ts"
-  const bar = this.$schema.$$get('lib'); // --> undefined
-  console.log(foo);
-  console.log(bar);
-  */
-
   public get dest(): string {
     return path.resolve(this.basePath, this.$schema.$$get('dest'));
   }
@@ -72,13 +65,45 @@ export class NgPackage {
   }
 
   /** Build artefacts */
-  public get artefacts() {
+  public get artefacts(): NgArtefacts {
     const main: string = `bundles/${this.meta.name}.umd.js`;
     const module: string = `${this.meta.scope}/${this.meta.name}.es5.js`;
     const es2015: string = `${this.meta.scope}/${this.meta.name}.js`;
     const typings: string = `${this.flatModuleFileName}.d.ts`;
+    const metadata: string = `${this.flatModuleFileName}.metadata.json`;
 
-    return { main, module, es2015, typings };
+    return { main, module, es2015, typings, metadata };
   }
 
+}
+
+/** Generated build artefacts for an Angular library. */
+export interface NgArtefacts {
+
+  /** Main JavaScript bundle in UMD (universal-module definition) and ES5 syntax. */
+  main: string;
+
+  /** Flat ECMAScript module in ES5 sxntax (FESM'5). */
+  module: string;
+
+  /** Flat ECMAScript module in ES2015 syntax (FESM'15). */
+  es2015: string;
+
+  /** TypeScript type definition file. */
+  typings: string;
+
+  /** Ahead-of-Time metadata (`.metadata.json`) file. */
+  metadata: string;
+}
+
+/**
+ * One individual entrypoint for an Angular library that is being packaged.
+ *
+ * An `NgPackage` may have several entrypoints (primary and secondaries).
+ * One `NgEntrypoint` gets compiled and bundled to a set of `NgArtefacts`.
+ */
+export interface NgEntrypoint {
+
+  /** TypeScript source file that serves as the entrypoint. */
+  entryFile: string;
 }

--- a/src/lib/ng-packagr.ts
+++ b/src/lib/ng-packagr.ts
@@ -1,19 +1,13 @@
 import * as path from 'path';
 
 // BUILD STEP IMPLEMENTATIONS
-import { processAssets } from './steps/assets';
-import { ngc, prepareTsConfig } from './steps/ngc';
-import { createPackage, readPackage } from './steps/package';
-import { rollup } from './steps/rollup';
-import { remapSourcemap } from './steps/sorcery';
-import { downlevelWithTsc } from './steps/tsc';
+import { readPackage, writePackage } from './steps/package';
 import { copyFiles } from './util/copy';
-import { modifyJsonFiles } from './util/json';
 import { rimraf } from './util/rimraf';
-
+import { generateNgBundle } from './bundler';
 
 // Logging
-import { error, warn, info, success, debug } from './util/log';
+import * as log from './util/log';
 
 // `ng-package.json` config
 import { NgPackage } from './model/ng-package';
@@ -29,7 +23,7 @@ export interface NgPackagrCliArguments {
 
 
 export const ngPackage = (opts: NgPackagrCliArguments): Promise<any> => {
-  info(`Building Angular library from ${opts.project}`);
+  log.info(`Building Angular library from ${opts.project}`);
   if (!path.isAbsolute(opts.project)) {
     opts.project = path.resolve(process.cwd(), opts.project);
   }
@@ -48,70 +42,20 @@ export const ngPackage = (opts: NgPackagrCliArguments): Promise<any> => {
         rimraf(p.workingDirectory)
       ]);
     })
-    // 2. ASSETS
-    .then(() => processAssets(ngPkg.src, `${ngPkg.workingDirectory}/ts`))
-    // 3. NGC
-    .then(() => prepareTsConfig(ngPkg, `${ngPkg.workingDirectory}/ts/tsconfig.lib.json`)
-      .then((tsConfigFile: string) => ngc(tsConfigFile, `${ngPkg.workingDirectory}/ts`))
-      .then((es2015EntryFile: string) =>
-        // XX: see #46 - ngc only references to closure-annotated ES6 sources
-        remapSourcemap(`${ngPkg.workingDirectory}/ts/${ngPkg.flatModuleFileName}.js`)
-          .then(() => Promise.resolve(es2015EntryFile)))
-    )
-    // 4. FESM15: ROLLUP
-    .then((es2015EntryFile: string) =>
-      rollup({
-        moduleName: ngPkg.meta.name,
-        entry: es2015EntryFile,
-        format: 'es',
-        dest: `${ngPkg.workingDirectory}/${ngPkg.artefacts.es2015}`,
-        externals: ngPkg.libExternals
-      })
-      // XX ... rollup generates relative paths in sourcemaps. It would be nice to re-locate source map files
-      // so that `@scope/name/foo/bar.ts` shows up as path in the browser...
-      .then(() => remapSourcemap(`${ngPkg.workingDirectory}/${ngPkg.artefacts.es2015}`))
-    )
-    // 5. FESM5: TSC
-    .then(() =>
-      downlevelWithTsc(
-        `${ngPkg.workingDirectory}/${ngPkg.artefacts.es2015}`,
-        `${ngPkg.workingDirectory}/${ngPkg.artefacts.module}`)
-      .then(() => remapSourcemap(`${ngPkg.workingDirectory}/${ngPkg.artefacts.module}`))
-    )
-    // 6. UMD: ROLLUP
-    .then(() =>
-      rollup({
-        moduleName: ngPkg.meta.name,
-        entry: `${ngPkg.workingDirectory}/${ngPkg.artefacts.module}`,
-        format: 'umd',
-        dest: `${ngPkg.workingDirectory}/${ngPkg.artefacts.main}`,
-        externals: ngPkg.libExternals
-      })
-      .then(() => remapSourcemap(`${ngPkg.workingDirectory}/${ngPkg.artefacts.main}`))
-    )
-    // 7. COPY FILES
-    .then(() => copyFiles(`${ngPkg.workingDirectory}/${ngPkg.meta.scope}/**/*.{js,js.map}`, `${ngPkg.dest}/${ngPkg.meta.scope}`))
-    .then(() => copyFiles(`${ngPkg.workingDirectory}/bundles/**/*.{js,js.map}`, `${ngPkg.dest}/bundles`))
-    .then(() => copyFiles(`${ngPkg.workingDirectory}/ts/**/*.{d.ts,metadata.json}`, `${ngPkg.dest}`))
+    // 1. Generate bundle for primary entrypoint
+    .then(() => generateNgBundle(ngPkg, ngPkg))
+    // TODO: generate bundles for secondary entrypoints
+    // TODO: write package.json 'lite' for secondary entrypoints
+    // 2. WRITE NPM PACKAGE
     .then(() => copyFiles(`${ngPkg.src}/README.md`, ngPkg.dest))
     .then(() => copyFiles(`${ngPkg.src}/LICENSE`, ngPkg.dest))
-    // 8. SOURCEMAPS: RELOCATE PATHS
-    // XX ... modifyJsonFiles() should maybe called 'relocateSourceMaps()' in 'steps' folder
-    .then(() => modifyJsonFiles(`${ngPkg.dest}/**/*.js.map`, (sourceMap: any): any => {
-      sourceMap['sources'] = sourceMap['sources']
-        .map((path: string): string => path.replace('../ts',
-          ngPkg.meta.scope ? `~/${ngPkg.meta.scope}/${ngPkg.meta.name}` : `~/${ngPkg.meta.name}`));
-
-      return sourceMap;
-    }))
-    // 9. PACKAGE
-    .then(() => createPackage(ngPkg.src, ngPkg.dest, ngPkg.artefacts))
+    .then(() => writePackage(ngPkg.src, ngPkg.dest, ngPkg.artefacts))
     .then(() => {
-      success(`Built Angular library from ${ngPkg.src}, written to ${ngPkg.dest}`);
+      log.success(`Built Angular library from ${ngPkg.src}, written to ${ngPkg.dest}`);
     })
     .catch((err) => {
       // Report error messages and throw the error further up
-      error(err);
+      log.error(err);
       return Promise.reject(err);
     });
 

--- a/src/lib/steps/package.ts
+++ b/src/lib/steps/package.ts
@@ -41,7 +41,7 @@ export const readPackage = (file: string): Promise<NgPackage> => {
  * @param dest Destination folder
  * @param additionalProperties These properties are added to the `package.json`
  */
-export const createPackage = (src: string, dest: string, additionalProperties?: {}): Promise<any> => {
+export const writePackage = (src: string, dest: string, additionalProperties?: {}): Promise<any> => {
 
   return readJson(path.resolve(src, 'package.json')).then((packageJson) => {
     // set additional properties


### PR DESCRIPTION
Serves a step towards secondary entrypoints.

## I'm submitting a...

- [ ] Bug Fix
- [ ] Feature
- [x] Other (Refactoring, Added tests, Documentation, ...)


## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern, see current [`.vcmrc`](https://github.com/dherges/ng-packagr/blob/master/.vcmrc)
- [ ] Tests for the changes have been added


## Description

Extract Angular bundling for `(entryFile: string) => { module, main, ..}`. Step towards secondary entrypoints.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
