### PR TITLE
ci: include `ng` cli consumer build in test script

### DIFF
--- a/integration/consumer.sh
+++ b/integration/consumer.sh
@@ -1,18 +1,33 @@
 #!/bin/bash
-cd integration/sample_custom
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$parent_path"
+echo "Running consumer builds in $parent_path"
+
+# Prepare 'sample-custom'
+pushd samples/custom/dist
 yarn unlink
 yarn link
-cd ../..
+popd
 
-cd integration/consumer-ng-cli
-yarn link sample-custom
+# Prepare '@sample/material'
+pushd samples/material/dist
+yarn unlink
+yarn link
+popd
+
+# Build ng cli app
+pushd consumers/ng-cli
 yarn install
+yarn link sample-custom
+yarn link @sample/material
 yarn build:dev
 yarn build:prod:jit
 yarn build:prod:aot
-cd ../..
+popd
 
-node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es2015 --module es2015
-node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es5 --module es2015
-node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es5 --module umd
-node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es5 --module commonjs
+
+
+# node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es2015 --module es2015
+# node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es5 --module es2015
+# node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es5 --module umd
+# node_modules/.bin/tsc -p integration/consumer-tsc/tsconfig.json --target es5 --module commonjs

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "samples:dev": "node integration/samples.js",
     "samples:test": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --compilers ts:ts-node/register integration/samples/*/specs/**/*.ts",
     "consumer": "integration/consumer.sh",
-    "test": "yarn build && yarn samples && yarn samples:test",
+    "test": "yarn build && yarn samples && yarn samples:test && yarn consumer",
     "commitmsg": "commitlint -e"
   }
 }


### PR DESCRIPTION
## I'm submitting a...

- [ ] Bug Fix
- [ ] Feature
- [x] Other (Refactoring, Added tests, Documentation, ...)


## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern, see current [`.vcmrc`](https://github.com/dherges/ng-packagr/blob/master/.vcmrc)
- [x] Tests for the changes have been added


## Description

Motivation: integration testing from a consumer's point of view.

Assert that importing the generated libraries in an `ng` cli app produces build success.

Details:
 - adds a `ng` CLI app
 - `yarn link` sample libraries to CLI app
 - build the CLI app in several ways:
    - `ng build --target development` (dev w/o AoT)
    - `ng build --target production` (prod w/o AoT)
    - `ng build --target production --aot` (prod w AoT)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
