### PR TITLE
feat: add json schema for `package.json` with custom `ngPackage` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ Configuration is picked up from the cli `-p` parameter, then from the default lo
 
 To configure with `package.json`, put your ng-package configuration 
 in the `ngPackage` field:
+
 ```json
 {
+  "$schema": "./node_modules/ng-packagr/package.schema.json",
   "ngPackage": {
     "lib": {
       "entryFile": "public_api.ts"
@@ -74,6 +76,8 @@ in the `ngPackage` field:
   }
 }
 ```
+
+Note: the JSON `$schema` reference enables JSON editing support (autocompletion) for the custom `ngPackage` property in an IDE like [VSCode](https://github.com/Microsoft/vscode).
 
 #### More Examples
 

--- a/integration/samples/core/ng-package.json
+++ b/integration/samples/core/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../src/lib/ng-package.schema.json",
+  "$schema": "../../../src/ng-package.schema.json",
   "lib": {
     "entryFile": "public_api.ts",
     "externals": {

--- a/integration/samples/custom/ng-package.json
+++ b/integration/samples/custom/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../src/lib/ng-package.schema.json",
+  "$schema": "../../../src/ng-package.schema.json",
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/integration/samples/externals/ng-package.json
+++ b/integration/samples/externals/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../src/lib/ng-package.schema.json",
+  "$schema": "../../../src/ng-package.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/integration/samples/material/ng-package.json
+++ b/integration/samples/material/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../src/lib/ng-package.schema.json",
+  "$schema": "../../../src/ng-package.schema.json",
   "lib": {
     "entryFile": "public_api.ts"
   }

--- a/integration/samples/package-json/package.json
+++ b/integration/samples/package-json/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../src/package.schema.json",
   "name": "@sample/package-json",
   "description": "A sample library with configuration in package.json",
   "version": "1.0.0-pre.0",
@@ -9,7 +10,6 @@
     "@angular/common": "^4.1.2"
   },
   "ngPackage": {
-    "$schema": "../../../src/lib/ng-package.schema.json",
     "lib": {
       "entryFile": "public_api.ts"
     }

--- a/integration/samples/typings/ng-package.json
+++ b/integration/samples/typings/ng-package.json
@@ -1,3 +1,3 @@
 {
-  "$schema": "../../../src/lib/ng-package.schema.json"
+  "$schema": "../../../src/ng-package.schema.json"
 }

--- a/src/package.schema.json
+++ b/src/package.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "allOf": [
+    { "$ref": "http://json.schemastore.org/package" },
+    {
+      "properties": {
+        "ngPackage": { "$ref": "./ng-package.schema.json" }
+      },
+      "required": []
+    }
+  ]
+}


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

See review discussions in #169

By referencing `$schema: "./node_modules/ng-packagr/package.schema.json"` in a `package.json` you get JSON editing support for the custom `ngPackage` property in an IDE.

```json
{
  "$schema": "./node_modules/ng-packagr/package.schema.json",
  /* .. */
}
```

![schema](https://user-images.githubusercontent.com/901354/31388365-16deb536-adce-11e7-8ef5-536d55a5265f.gif)



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
