### PR TITLE
fix: prevent BUILD ERROR if unrelated package.json exists in a sub-folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ my_package
 
 The contents of the secondary `package.json` can be as simple as:
 ```json
+{
+  ngPackage: {}
+}
 ```
 
-No, that is not a typo. No name is required. No version is required. Not even a json object is required. 
+No, that is not a typo. No name is required. No version is required. 
 It's all handled for you by ng-packagr!
 When built, the secondary bundles would be accessible as `$(your-primary-package-name)/testing`.
 

--- a/integration/samples/secondary/should-be-ignored/bar/bar.component.html
+++ b/integration/samples/secondary/should-be-ignored/bar/bar.component.html
@@ -1,0 +1,1 @@
+<h1 class="foo">bar!</h1>

--- a/integration/samples/secondary/should-be-ignored/bar/bar.component.scss
+++ b/integration/samples/secondary/should-be-ignored/bar/bar.component.scss
@@ -1,0 +1,5 @@
+$color: '#ff0000';
+
+.foo {
+    background-color: $color;
+}

--- a/integration/samples/secondary/should-be-ignored/bar/bar.component.ts
+++ b/integration/samples/secondary/should-be-ignored/bar/bar.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'bar-component',
+  templateUrl: './bar.component.html',
+  styleUrls: ['./bar.component.scss']
+})
+export class BarComponent {
+}

--- a/integration/samples/secondary/should-be-ignored/index.ts
+++ b/integration/samples/secondary/should-be-ignored/index.ts
@@ -1,0 +1,1 @@
+export * from './bar/bar.component';

--- a/integration/samples/secondary/should-be-ignored/package.json
+++ b/integration/samples/secondary/should-be-ignored/package.json
@@ -1,0 +1,6 @@
+{
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  }
+}

--- a/integration/samples/secondary/specs/package.ts
+++ b/integration/samples/secondary/specs/package.ts
@@ -15,6 +15,10 @@ describe(`@sample/secondary`, () => {
       expect(PACKAGE).to.be.ok;
     });
 
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
+    });
+
     it(`should be named '@sample/secondary-lib'`, () => {
       expect(PACKAGE['name']).to.equal('@sample/secondary-lib');
     });
@@ -47,6 +51,10 @@ describe(`@sample/secondary`, () => {
       expect(PACKAGE).to.be.ok;
     });
 
+    it(`should not have ngPackage field`, () => {
+      expect(PACKAGE.ngPackage).to.be.undefined;
+    });
+
     it(`should be named '@sample/secondary-lib/sub-module'`, () => {
       expect(PACKAGE['name']).to.equal('@sample/secondary-lib/sub-module');
     });
@@ -65,6 +73,14 @@ describe(`@sample/secondary`, () => {
 
     it(`should reference "typings" files`, () => {
       expect(PACKAGE['typings']).to.equal('sub-module.d.ts');
+    });
+  });
+
+  describe(`should-be-ignored/package.json`, () => {
+    const BASE = path.resolve(__dirname, '..', 'dist', 'should-be-ignored');
+
+    it(`should not exist`, () => {
+      expect(() => fs.readFileSync(`${BASE}/package.json`, 'utf-8')).throw();
     });
   });
 


### PR DESCRIPTION
## I'm submitting a ...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

This should fix #213

Now the ngPackage field is required in a package.json in order to be considered a secondary package.

## Does this PR introduce a breaking change?

```
[ ] Yes- would be yes if the RC releases are considered, otherwise...
[x] No
```
