### PR TITLE
fix: depend on user's typescript and tsc-wrapped

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ng-packagr": "./cli/main.js"
   },
   "dependencies": {
-    "@angular/tsc-wrapped": "^4.4.5",
     "@ngtools/json-schema": "^1.1.0",
     "autoprefixer": "^7.1.1",
     "browserslist": "^2.1.5",
@@ -46,9 +45,12 @@
     "sorcery": "^0.10.0",
     "stylus": "^0.54.5",
     "ts-node": "^3.0.4",
-    "typescript": "^2.3.4",
     "uglify-js": "^3.0.7",
     "vinyl-fs": "^2.4.4"
+  },
+  "peerDependencies": {
+    "@angular/tsc-wrapped": "~4.4.5",
+    "typescript": "~2.3.4"
   },
   "devDependencies": {
     "@angular/cdk": "^2.0.0-beta.11",
@@ -56,6 +58,7 @@
     "@angular/core": "^4.4.5",
     "@angular/http": "^4.4.5",
     "@angular/platform-browser": "^4.4.5",
+    "@angular/tsc-wrapped": "~4.4.5",
     "@commitlint/cli": "^4.0.0",
     "@commitlint/config-angular": "^4.2.0",
     "@types/chai": "^4.0.0",
@@ -78,6 +81,7 @@
     "rxjs": "^5.4.0",
     "sinon": "^4.0.0",
     "standard-version": "^4.0.0",
+    "typescript": "~2.3.4",
     "zone.js": "^0.8.10"
   },
   "private": true,

--- a/src/lib/util/json.ts
+++ b/src/lib/util/json.ts
@@ -1,7 +1,8 @@
-const glob = require('glob')
+import * as glob from 'glob';
 import { readJson, writeJson } from 'fs-extra';
 import { promisify } from './promisify';
 import { debug } from './log';
+
 /**
  * Modifies a set of JSON files by invoking `modifyFn`
  *
@@ -33,8 +34,8 @@ export async function modifyJsonFiles(globPattern: string, modifyFn: (jsonObj: a
 export async function tryReadJson(filePath: string): Promise<any> {
   try {
     return await readJson(filePath);
-  } catch {
+  } catch (e) {
     // this means the file was empty or not json, which is fine
-    return {};
+    return await Promise.resolve({});
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@
   dependencies:
     tslib "^1.7.1"
 
-"@angular/tsc-wrapped@^4.4.5":
+"@angular/tsc-wrapped@~4.4.5":
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.4.6.tgz#16787cbbf50bdc7e738123b19c32527f244e178d"
   dependencies:
@@ -3468,9 +3468,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.3.4:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@~2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION


## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Previously, a user of ng-packagr could install an incompatible typescript version for ng-packagr. Prevent inadvertent typescript installs by depending on a user's typescript isntallation (peerDependencies). Same for tsc-wrapped.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
