### PR TITLE
[WIP] feat: read `NgPackageConfig` from multiple locations

### DIFF
--- a/integration/samples.js
+++ b/integration/samples.js
@@ -5,8 +5,7 @@ process.env.DEBUG = true;
 const PATH = path.resolve(__dirname, 'samples');
 const SAMPLES = fs.readdirSync(PATH)
   .map(dir => path.resolve(PATH, dir))
-  .filter(file => fs.lstatSync(file).isDirectory())
-  .map(dir => path.resolve(dir, 'ng-package.json'));
+  .filter(file => fs.lstatSync(file).isDirectory());
 
 
 // @see https://github.com/TypeStrong/ts-node#programmatic-usage

--- a/integration/samples.sh
+++ b/integration/samples.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 for D in `find ./integration/samples/* -maxdepth 0 -type d`
 do
+  if [ -f ${D}/ng-package.json ]; then
     node dist/cli/main.js -p ${D}/ng-package.json
+  else
+    node dist/cli/main.js -p ${D}/package.json
+  fi
 done

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,10 +1,9 @@
 #! /usr/bin/env node
-
 import * as program from 'commander';
 import * as path from 'path';
-import { createNgPackage, NgPackagrCliArguments } from './../lib/ng-packagr';
+import { createNgPackage, CliArguments } from '../lib/ng-packagr';
 
-const DEFAULT_PROJECT_PATH = path.resolve(process.cwd(), 'ng-package.json');
+const DEFAULT_PROJECT_PATH = process.cwd();
 
 function parseProjectPath(parsed: string): string {
   return parsed || DEFAULT_PROJECT_PATH;
@@ -14,12 +13,10 @@ program
   .name('ng-packagr')
   .option(
     '-p, --project <path>',
-    'Path to the \'ng-package.json\' or \'package.json\' file.',
+    'Path to the \'package.json\' or \'ng-package.json\' or \'ng-package.js\' file.',
     parseProjectPath,
     DEFAULT_PROJECT_PATH)
   .parse(process.argv);
 
-const cliArguments: any = program;
-
-createNgPackage(cliArguments as NgPackagrCliArguments)
+createNgPackage((program as any) as CliArguments)
   .catch((err) => process.exit(111));

--- a/src/lib/ng-packagr.ts
+++ b/src/lib/ng-packagr.ts
@@ -15,13 +15,15 @@ import * as log from './util/log';
 import { NgPackageData } from './model/ng-package-data';
 
 
-/** CLI arguments passed to `ng-packagr` and `ngPackage()`. */
-export interface NgPackagrCliArguments {
+/**
+ * Arguments passed to `ng-packagr` binary (from CLI) and `createNgPackage()`.
+ */
+export interface CliArguments {
   /** Path to the 'ng-package.json' file */
   project: string
 }
 
-export async function createNgPackage(opts: NgPackagrCliArguments): Promise<void> {
+export async function createNgPackage(opts: CliArguments): Promise<void> {
   log.info(`Building Angular library`);
 
   let buildDirectoryRoot: string;
@@ -45,7 +47,10 @@ export async function createNgPackage(opts: NgPackagrCliArguments): Promise<void
     await copyFiles(`${rootPackage.sourcePath}/README.md`, rootPackage.destinationPath);
     await copyFiles(`${rootPackage.sourcePath}/LICENSE`, rootPackage.destinationPath);
 
-    log.success(`Built Angular library from ${rootPackage.sourcePath}, written to ${rootPackage.destinationPath}`);
+    log.success(
+`Built Angular library
+  from:       ${rootPackage.sourcePath}
+  written to: ${rootPackage.destinationPath}`);
   } catch (error) {
     // Report error messages and throw the error further up
     log.error(error);


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

The preferred order of declaring the Angular Package Config is:
 - `package.json` with a `ngPackage` property
 - `ng-package.json`
 - `ng-package.js` exporting the config (thru `module.exports` or `exports default`)
 - a directory containing one of the above

Relates to #190 

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
