### PR TITLE
fix: include scope name in module name of Rollup bundle

### DIFF
--- a/integration/samples/core/specs/bundle.ts
+++ b/integration/samples/core/specs/bundle.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/core`, () => {
+
+  describe(`bundle core.umd.js`, () => {
+    let BUNDLE;
+    before(() => {
+      BUNDLE = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'core.umd.js'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(BUNDLE).to.be.ok;
+    });
+
+    it(`should export the module with module name 'sample.core'`, () => {
+      expect(BUNDLE).to.contain(`global.sample.core = {}`);
+    });
+  });
+
+});

--- a/integration/samples/secondary/specs/bundle.ts
+++ b/integration/samples/secondary/specs/bundle.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/secondary`, () => {
+
+  describe(`bundle secondary-lib.umd.js`, () => {
+    let BUNDLE;
+    before(() => {
+      BUNDLE = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'secondary-lib.umd.js'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(BUNDLE).to.be.ok;
+    });
+
+    it(`should export the root module with module name 'sample.secondary-lib'`, () => {
+      expect(BUNDLE).to.contain(`global.sample['secondary-lib'] = {}`);
+    });
+  });
+
+  describe(`bundle secondary-lib-sub-module.umd.js`, () => {
+    let BUNDLE;
+    before(() => {
+      BUNDLE = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'secondary-lib-sub-module.umd.js'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(BUNDLE).to.be.ok;
+    });
+
+    it(`should export the secondary module with module name 'sample.secondary-lib.sub-module'`, () => {
+      expect(BUNDLE).to.contain(`global.sample['secondary-lib']['sub-module'] = {}`);
+    });
+  });
+
+});

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -41,7 +41,7 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
   // 3. FESM15: ROLLUP
   log.info('Compiling to FESM15');
   await rollup({
-    moduleName: ngPkg.packageNameWithoutScope,
+    moduleName: ngPkg.moduleName,
     entry: es2015EntryFile,
     format: 'es',
     dest: artifactPaths.es2015,
@@ -59,7 +59,7 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
   // 5. UMD: ROLLUP
   log.info('Compiling to UMD');
   await rollup({
-    moduleName: ngPkg.packageNameWithoutScope,
+    moduleName: ngPkg.moduleName,
     entry: artifactPaths.module,
     format: 'umd',
     dest: artifactPaths.main,

--- a/src/lib/model/ng-package-data.ts
+++ b/src/lib/model/ng-package-data.ts
@@ -9,6 +9,7 @@ export class NgPackageData {
   public readonly pathOffsetFromSourceRoot: string;
   public readonly fullPackageName: string;
   public readonly packageNameWithoutScope: string;
+  public readonly moduleName: string;
   public readonly scope?: string;
   public readonly flatModuleFileName: string;
   public readonly entryFile: string;
@@ -37,6 +38,7 @@ export class NgPackageData {
     // destination path of secondary modules is not configurable - this is to meet the Angular package format.
     this.destinationPath = rootDestinationPath + this.pathOffsetFromSourceRoot;
     this.fullPackageName = path.ensureUnixPath(rootPackageName + this.pathOffsetFromSourceRoot);
+    this.moduleName = this.fullPackageName.replace(SCOPE_PREFIX, '').split(SCOPE_NAME_SEPARATOR).join('.');
 
     if (this.fullPackageName.startsWith(SCOPE_PREFIX)) {
       const firstSeparatorIndex: number = this.fullPackageName.indexOf(SCOPE_NAME_SEPARATOR);
@@ -67,7 +69,7 @@ export class NgPackageData {
       this.entryFile = 'public_api.ts';
     }
 
-    // Each entry point gets it's own unique build directory based upon the package name.
+    // Each entry point gets its own unique build directory based upon the package name.
     const packageBuildFolderName: string = this.fullPackageName.replace(SCOPE_NAME_SEPARATOR, '-');
     this.buildDirectory = path.resolve(this.rootSourcePath, DEFAULT_BUILD_FOLDER, packageBuildFolderName);
   }


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

This PR changes the UMD module name of libraries to include the scope name. See #251 for background information on this change.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Yes, this is a breaking change for users that have published libraries before. This change causes new builds to get assigned a different module name if a scope is being used.