### PR TITLE
Add missing mapTo to RxJS globals

### DIFF
--- a/src/lib/conf/rollup.globals.ts
+++ b/src/lib/conf/rollup.globals.ts
@@ -113,6 +113,7 @@ export const ROLLUP_GLOBALS = {
   'rxjs/add/operator/letProto':       'Rx.Observable.prototype',
   'rxjs/add/operator/lift':           'Rx.Observable.prototype',
   'rxjs/add/operator/map':            'Rx.Observable.prototype',
+  'rxjs/add/operator/mapTo':          'Rx.Observable.prototype',
   'rxjs/add/operator/materialize':    'Rx.Observable.prototype',
   'rxjs/add/operator/max':            'Rx.Observable.prototype',
   'rxjs/add/operator/merge':          'Rx.Observable.prototype',


### PR DESCRIPTION
## I'm add the missing RxJS operator mapTo to the rollup globals.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x] No
```
