### PR TITLE
feat: align distributed files with `Angular Package Format v5.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ We keep track of user questions in GitHub's issue tracker and try to build a doc
 
 ## Knowledge
 
-[Angular Package Format v4.0](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview), design document at Google Docs
+[Angular Package Format v5.0](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview), design document at Google Docs
 
 
 Packaging Angular - Jason Aden at ng-conf 2017 ([28min talk](https://youtu.be/unICbsPGFIA))

--- a/integration/samples/core/specs/es5-api.ts
+++ b/integration/samples/core/specs/es5-api.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as API from '../dist/@sample/core.es5.js';
+import * as API from '../dist/esm5/core.js';
 
 describe(`@sample/core`, () => {
 
-  describe(`core.es5.js`, () => {
+  describe(`esm5/core.js`, () => {
 
     it(`should exist`, () => {
       expect(API).to.be.ok;

--- a/integration/samples/core/specs/package.ts
+++ b/integration/samples/core/specs/package.ts
@@ -24,11 +24,11 @@ describe(`@sample/core`, () => {
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2014)`, () => {
-      expect(PACKAGE['module']).to.equal('@sample/core.es5.js');
+      expect(PACKAGE['module']).to.equal('esm5/core.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('@sample/core.js');
+      expect(PACKAGE['es2015']).to.equal('esm2015/core.js');
     });
 
     it(`should reference "typings" files`, () => {

--- a/integration/samples/custom/specs/es5-api.ts
+++ b/integration/samples/custom/specs/es5-api.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as API from '../dist/sample-custom.es5.js';
+import * as API from '../dist/esm5/sample-custom.js';
 
 describe(`sample-custom`, () => {
 
-  describe(`sample-custom.es5.js`, () => {
+  describe(`esm5/sample-custom.js`, () => {
 
     it(`should exist`, () => {
       expect(API).to.be.ok;

--- a/integration/samples/custom/specs/package.ts
+++ b/integration/samples/custom/specs/package.ts
@@ -30,11 +30,11 @@ describe(`sample-custom`, () => {
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2015)`, () => {
-      expect(PACKAGE['module']).to.equal('sample-custom.es5.js');
+      expect(PACKAGE['module']).to.equal('esm5/sample-custom.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('sample-custom.js');
+      expect(PACKAGE['es2015']).to.equal('esm2015/sample-custom.js');
     });
 
     it(`should reference "typings" files`, () => {

--- a/integration/samples/jsx/specs/react-jsx.ts
+++ b/integration/samples/jsx/specs/react-jsx.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as API from '../dist/@sample/jsx.es5.js';
+import * as API from '../dist/esm5/jsx.js';
 
 describe(`@sample/jsx`, () => {
 

--- a/integration/samples/material/specs/package.ts
+++ b/integration/samples/material/specs/package.ts
@@ -24,11 +24,11 @@ describe(`@sample/material`, () => {
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2014)`, () => {
-      expect(PACKAGE['module']).to.equal('@sample/material.es5.js');
+      expect(PACKAGE['module']).to.equal('esm5/material.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('@sample/material.js');
+      expect(PACKAGE['es2015']).to.equal('esm2015/material.js');
     });
 
     it(`should reference "typings" files`, () => {

--- a/integration/samples/same-name/ng-package.json
+++ b/integration/samples/same-name/ng-package.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../src/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public_api.ts",
+    "externals": {
+      "rxjs/operator/map": "Rx.Observable.prototype"
+    }
+  }
+}

--- a/integration/samples/same-name/package.json
+++ b/integration/samples/same-name/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sample/testing",
+  "description": "A sample library with folder layout from Angular core packages",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/common": "^4.1.3",
+    "@angular/core": "^4.1.3",
+    "@angular/router": "^4.1.3",
+    "rxjs": "^5.0.1",
+    "zone.js": "^0.8.4"
+  },
+  "scripts": {
+    "test": "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
+  }
+}

--- a/integration/samples/same-name/public_api.ts
+++ b/integration/samples/same-name/public_api.ts
@@ -1,0 +1,2 @@
+export * from './src/angular.component';
+export * from './src/angular.module';

--- a/integration/samples/same-name/specs/bundle.ts
+++ b/integration/samples/same-name/specs/bundle.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/same-name`, () => {
+
+  describe(`bundle testing.umd.js`, () => {
+    let BUNDLE;
+    before(() => {
+      BUNDLE = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'testing.umd.js'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(BUNDLE).to.be.ok;
+    });
+
+    it(`should export the module with module name 'sample.testing'`, () => {
+      expect(BUNDLE).to.contain(`global.sample.testing = {}`);
+    });
+  });
+
+
+  describe(`bundle testing-testing.umd.js`, () => {
+    let BUNDLE;
+    before(() => {
+      BUNDLE = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'testing-testing.umd.js'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(BUNDLE).to.be.ok;
+    });
+
+    it(`should export the module with module name 'sample.testing.testing'`, () => {
+      expect(BUNDLE).to.contain(`global.sample.testing.testing = {}`);
+    });
+  });
+
+});

--- a/integration/samples/same-name/specs/es5-api.ts
+++ b/integration/samples/same-name/specs/es5-api.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as API from '../dist/esm5/testing.js';
+import * as APITesting from '../dist/esm5/testing/testing.js';
+
+describe(`@sample/same-name`, () => {
+
+  describe(`esm5/testing.js`, () => {
+
+    it(`should exist`, () => {
+      expect(API).to.be.ok;
+    });
+
+    it(`should export AngularComponent`, () => {
+      expect(API.AngularComponent).to.be.ok;
+    });
+
+  });
+
+  describe(`esm5/testing/testing.js`, () => {
+
+    it(`should exist`, () => {
+      expect(APITesting).to.be.ok;
+    });
+
+    it(`should export AngularComponent`, () => {
+      expect(APITesting.AngularComponent).to.be.ok;
+    });
+
+  });
+});

--- a/integration/samples/same-name/specs/metadata.ts
+++ b/integration/samples/same-name/specs/metadata.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/same-name`, () => {
+
+  describe(`testing.metadata.json`, () => {
+    let METADATA;
+    before(() => {
+      METADATA = require('../dist/testing.metadata.json');
+    });
+
+    it(`should exist`, () => {
+      expect(METADATA).to.be.ok;
+    });
+
+    it(`should be version 4`, () => {
+      expect(METADATA.version).to.equal(4);
+    });
+
+    it(`should be version 4`, () => {
+      expect(METADATA.version).to.equal(4);
+    });
+
+    it(`should "importAs": "@sample/testing"`, () => {
+      expect(METADATA['importAs']).to.equal('@sample/testing');
+    });
+
+    it(`should be "__symbolic": "module"`, () => {
+      expect(METADATA['__symbolic']).to.equal('module');
+    });
+
+  });
+});

--- a/integration/samples/same-name/specs/metadata.ts
+++ b/integration/samples/same-name/specs/metadata.ts
@@ -31,4 +31,32 @@ describe(`@sample/same-name`, () => {
     });
 
   });
+
+  describe(`testing/testing.metadata.json`, () => {
+    let METADATA;
+    before(() => {
+      METADATA = require('../dist/testing/testing.metadata.json');
+    });
+
+    it(`should exist`, () => {
+      expect(METADATA).to.be.ok;
+    });
+
+    it(`should be version 4`, () => {
+      expect(METADATA.version).to.equal(4);
+    });
+
+    it(`should be version 4`, () => {
+      expect(METADATA.version).to.equal(4);
+    });
+
+    it(`should "importAs": "@sample/testing"`, () => {
+      expect(METADATA['importAs']).to.equal('@sample/testing/testing');
+    });
+
+    it(`should be "__symbolic": "module"`, () => {
+      expect(METADATA['__symbolic']).to.equal('module');
+    });
+
+  });
 });

--- a/integration/samples/same-name/specs/package.ts
+++ b/integration/samples/same-name/specs/package.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+const BASE = path.resolve(__dirname, '..', 'dist');
+const BASE_TESTING = path.resolve(__dirname, '..', 'dist', 'testing');
+
+describe(`@sample/same-name`, () => {
+
+  describe(`package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = JSON.parse(fs.readFileSync(`${BASE}/package.json`, 'utf-8'));
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should be named '@sample/testing'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/testing');
+    });
+
+    it(`should reference "main" bundle (UMD)`, () => {
+      expect(PACKAGE['main']).to.equal('bundles/testing.umd.js');
+    });
+
+    it(`should reference "module" bundle (FESM5, also FESM2014)`, () => {
+      expect(PACKAGE['module']).to.equal('esm5/testing.js');
+    });
+
+    it(`should reference "es2015" bundle (FESM2015)`, () => {
+      expect(PACKAGE['es2015']).to.equal('esm2015/testing.js');
+    });
+
+    it(`should reference "typings" files`, () => {
+      expect(PACKAGE['typings']).to.equal('testing.d.ts');
+    });
+
+  });
+
+  describe(`testing/package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = JSON.parse(fs.readFileSync(`${BASE_TESTING}/package.json`, 'utf-8'));
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+
+    it(`should be named '@sample/testing/testing'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/testing/testing');
+    });
+
+    it(`should reference "main" bundle (UMD)`, () => {
+      expect(PACKAGE['main']).to.equal('../bundles/testing-testing.umd.js');
+    });
+
+    it(`should reference "module" bundle (FESM5, also FESM2014)`, () => {
+      expect(PACKAGE['module']).to.equal('../esm5/testing/testing.js');
+    });
+
+    it(`should reference "es2015" bundle (FESM2015)`, () => {
+      expect(PACKAGE['es2015']).to.equal('../esm2015/testing/testing.js');
+    });
+
+    it(`should reference "typings" files`, () => {
+      expect(PACKAGE['typings']).to.equal('testing.d.ts');
+    });
+
+  });
+});

--- a/integration/samples/same-name/specs/typings.ts
+++ b/integration/samples/same-name/specs/typings.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/same-name`, () => {
+
+  describe(`testing.d.ts`, () => {
+    let TYPINGS;
+    before(() => {
+      TYPINGS = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'testing.d.ts'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(TYPINGS).to.be.ok;
+    });
+  });
+
+  describe(`testing/testing.d.ts`, () => {
+    let TYPINGS;
+    before(() => {
+      TYPINGS = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'testing', 'testing.d.ts'), 'utf-8');
+    });
+
+    it(`should exist`, () => {
+      expect(TYPINGS).to.be.ok;
+    });
+  });
+
+});

--- a/integration/samples/same-name/specs/umd.ts
+++ b/integration/samples/same-name/specs/umd.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/same-name`, () => {
+
+  describe(`testing.umd.min.js`, () => {
+    let API;
+    before(() => {
+      API = require('../dist/bundles/testing.umd.min.js');
+    });
+
+    it(`should exist`, () => {
+      expect(API).to.be.ok;
+    });
+
+    it(`should export AngularComponent`, () => {
+      expect(API.AngularComponent).to.be.ok;
+    });
+
+    it(`should export AngularModule`, () => {
+      expect(API.AngularModule).to.be.ok;
+    });
+
+  });
+
+  describe(`testing-testing.umd.min.js`, () => {
+    let API;
+    before(() => {
+      API = require('../dist/bundles/testing-testing.umd.min.js');
+    });
+
+    it(`should exist`, () => {
+      expect(API).to.be.ok;
+    });
+
+    it(`should export AngularComponent`, () => {
+      expect(API.AngularComponent).to.be.ok;
+    });
+
+    it(`should export AngularModule`, () => {
+      expect(API.AngularModule).to.be.ok;
+    });
+
+  });
+});

--- a/integration/samples/same-name/src/angular.component.ts
+++ b/integration/samples/same-name/src/angular.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+
+@Component({
+  selector: 'ng-component',
+  template: '<h1>Angular!</h1>'
+})
+export class AngularComponent {}

--- a/integration/samples/same-name/src/angular.module.ts
+++ b/integration/samples/same-name/src/angular.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AngularComponent } from './angular.component';
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    AngularComponent
+  ],
+  providers: [
+
+  ]
+})
+export class AngularModule {}

--- a/integration/samples/same-name/testing/ng-package.json
+++ b/integration/samples/same-name/testing/ng-package.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../../src/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public_api.ts",
+    "externals": {
+      "rxjs/operator/map": "Rx.Observable.prototype"
+    }
+  }
+}

--- a/integration/samples/same-name/testing/package.json
+++ b/integration/samples/same-name/testing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sample/testing/testing",
+  "description": "A sample library with folder layout from Angular core packages",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/common": "^4.1.3",
+    "@angular/core": "^4.1.3",
+    "@angular/router": "^4.1.3",
+    "rxjs": "^5.0.1",
+    "zone.js": "^0.8.4"
+  },
+  "scripts": {
+    "test": "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
+  }
+}

--- a/integration/samples/same-name/testing/public_api.ts
+++ b/integration/samples/same-name/testing/public_api.ts
@@ -1,0 +1,2 @@
+export * from './src/angular.component';
+export * from './src/angular.module';

--- a/integration/samples/same-name/testing/src/angular.component.ts
+++ b/integration/samples/same-name/testing/src/angular.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+
+@Component({
+  selector: 'ng-component',
+  template: '<h1>Angular!</h1>'
+})
+export class AngularComponent {}

--- a/integration/samples/same-name/testing/src/angular.module.ts
+++ b/integration/samples/same-name/testing/src/angular.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AngularComponent } from './angular.component';
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    AngularComponent
+  ],
+  providers: [
+
+  ]
+})
+export class AngularModule {}

--- a/integration/samples/secondary/specs/es2016-api.ts
+++ b/integration/samples/secondary/specs/es2016-api.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as API from '../dist/@sample/secondary-lib.js';
-import * as SECONDARY from '../dist/@sample/secondary-lib/sub-module.js'
+import * as API from '../dist/esm2015/secondary-lib.js';
+import * as SECONDARY from '../dist/esm2015/sub-module.js';
 
 describe(`@sample/secondary-lib`, () => {
 

--- a/integration/samples/secondary/specs/es5-api.ts
+++ b/integration/samples/secondary/specs/es5-api.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as API from '../dist/@sample/secondary-lib.es5.js';
-import * as SECONDARY from '../dist/@sample/secondary-lib/sub-module.es5.js'
+import * as API from '../dist/esm5/secondary-lib.js';
+import * as SECONDARY from '../dist/esm5/sub-module.js';
 
 describe(`@sample/secondary-lib`, () => {
 

--- a/integration/samples/secondary/specs/package.ts
+++ b/integration/samples/secondary/specs/package.ts
@@ -28,11 +28,11 @@ describe(`@sample/secondary`, () => {
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2015)`, () => {
-      expect(PACKAGE['module']).to.equal('@sample/secondary-lib.es5.js');
+      expect(PACKAGE['module']).to.equal('esm5/secondary-lib.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('@sample/secondary-lib.js');
+      expect(PACKAGE['es2015']).to.equal('esm2015/secondary-lib.js');
     });
 
     it(`should reference "typings" files`, () => {
@@ -64,11 +64,11 @@ describe(`@sample/secondary`, () => {
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2015)`, () => {
-      expect(PACKAGE['module']).to.equal('../@sample/secondary-lib/sub-module.es5.js');
+      expect(PACKAGE['module']).to.equal('../esm5/sub-module.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('../@sample/secondary-lib/sub-module.js');
+      expect(PACKAGE['es2015']).to.equal('../esm2015/sub-module.js');
     });
 
     it(`should reference "typings" files`, () => {

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -20,9 +20,9 @@ import * as log from './util/log';
 export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
 
   log.info(`Generating bundle for ${ngPkg.fullPackageName}`);
-  const artifactFactory: NgArtifactsFactory = new NgArtifactsFactory();
-  const baseBuildPath: string = `${ngPkg.buildDirectory}/ts${ngPkg.pathOffsetFromSourceRoot}`;
-  const artifactPaths: NgArtifacts = artifactFactory.calculateArtifactPathsForBuild(ngPkg);
+  const artifactFactory = new NgArtifactsFactory();
+  const baseBuildPath = `${ngPkg.buildDirectory}/ts${ngPkg.pathOffsetFromSourceRoot}`;
+  const artifactPaths = artifactFactory.calculateArtifactPathsForBuild(ngPkg);
 
   // 0. CLEAN BUILD DIRECTORY
   log.info('Cleaning bundle build directory');
@@ -34,9 +34,9 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
 
   // 2. NGC
   log.info('Running ngc');
-  const es2015EntryFile: string = await ngc(ngPkg, baseBuildPath);
+  const es2015EntryFile = await ngc(ngPkg, baseBuildPath);
   // XX: see #46 - ngc only references to closure-annotated ES6 sources
-  await remapSourceMap(`${baseBuildPath}/${ngPkg.flatModuleFileName}.js`);
+  await remapSourceMap(es2015EntryFile);
 
   // 3. FESM15: ROLLUP
   log.info('Compiling to FESM15');
@@ -69,7 +69,7 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
 
   // 6. UMD: Minify
   log.info('Minifying UMD bundle');
-  const minifiedFilePath: string = await minifyJsFile(artifactPaths.main);
+  const minifiedFilePath = await minifyJsFile(artifactPaths.main);
   await remapSourceMap(minifiedFilePath);
 
   // 7. SOURCEMAPS: RELOCATE ROOT PATHS
@@ -82,7 +82,7 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
 
   // 9. WRITE PACKAGE.JSON and OTHER DOC FILES
   log.info('Writing package metadata');
-  const packageJsonArtifactPaths: NgArtifacts = artifactFactory.calculateArtifactPathsForPackageJson(ngPkg);
+  const packageJsonArtifactPaths = artifactFactory.calculateArtifactPathsForPackageJson(ngPkg);
   await writePackage(ngPkg, packageJsonArtifactPaths);
 
   log.success(`Built Angular bundle for ${ngPkg.fullPackageName}`);

--- a/src/lib/model/ng-artifacts-factory.ts
+++ b/src/lib/model/ng-artifacts-factory.ts
@@ -12,12 +12,13 @@ export class NgArtifactsFactory {
       return this._makeEsmPackageNameVal;
     }
 
-    const { packageNameWithoutScope, flatModuleFileName, buildDirectory } = ngPkg;
+    const { packageNameWithoutScope, flatModuleFileName, buildDirectory, pathOffsetFromSourceRoot } = ngPkg;
 
     if (packageNameWithoutScope === flatModuleFileName) {
       this._makeEsmPackageNameVal = `${flatModuleFileName}.js`;
     } else {
-      const modulePath = path.join(buildDirectory, 'esm2015', `${flatModuleFileName}.js`);
+      const pathFromRoot = buildDirectory.replace(pathOffsetFromSourceRoot, "");
+      const modulePath = path.join(pathFromRoot, 'esm2015', `${flatModuleFileName}.js`);
       const pkgName = pathExistsSync(modulePath) ? packageNameWithoutScope : flatModuleFileName;
       this._makeEsmPackageNameVal = `${pkgName}.js`;
     }
@@ -30,13 +31,13 @@ export class NgArtifactsFactory {
   }
 
   private _unixPathJoin(...paths: string[]): string {
-    const joined: string = path.join(...paths);
+    const joined = path.join(...paths);
     return path.ensureUnixPath(joined);
   }
 
   public calculateArtifactPathsForBuild(ngPkg: NgPackageData): NgArtifacts {
     const { buildDirectory, pathOffsetFromSourceRoot, flatModuleFileName } = ngPkg;
-    const pathFromRoot: string = path.resolve(buildDirectory, pathOffsetFromSourceRoot);
+    const pathFromRoot = path.resolve(buildDirectory, pathOffsetFromSourceRoot);
 
     return {
       main: path.join(buildDirectory, 'bundles', this._makeUmdPackageName(ngPkg)),
@@ -49,7 +50,7 @@ export class NgArtifactsFactory {
 
   public calculateArtifactPathsForPackageJson(ngPkg: NgPackageData): NgArtifacts {
     const { sourcePath, rootSourcePath, flatModuleFileName } = ngPkg;
-    const rootPathFromSelf: string = path.relative(sourcePath, rootSourcePath);
+    const rootPathFromSelf = path.relative(sourcePath, rootSourcePath);
 
     return {
       main: this._unixPathJoin(rootPathFromSelf, 'bundles', this._makeUmdPackageName(ngPkg)),

--- a/src/lib/model/ng-artifacts-factory.ts
+++ b/src/lib/model/ng-artifacts-factory.ts
@@ -20,8 +20,8 @@ export class NgArtifactsFactory {
       main: path.join(buildDirectory, 'bundles', this._makeUmdPackageName(ngPkg)),
       module: path.join(buildDirectory, 'esm5', `${flatModuleFileName}.js`),
       es2015: path.join(buildDirectory, 'esm2015', `${flatModuleFileName}.js`),
-      typings: path.join(pathFromRoot, flatModuleFileName + '.d.ts'),
-      metadata: path.join(pathFromRoot, flatModuleFileName + '.metadata.json')
+      typings: path.join(pathFromRoot, `${flatModuleFileName}.d.ts`),
+      metadata: path.join(pathFromRoot, `${flatModuleFileName}.metadata.json`)
     }
   }
 

--- a/src/lib/model/ng-artifacts-factory.ts
+++ b/src/lib/model/ng-artifacts-factory.ts
@@ -17,7 +17,7 @@ export class NgArtifactsFactory {
     if (packageNameWithoutScope === flatModuleFileName) {
       this._makeEsmPackageNameVal = `${flatModuleFileName}.js`;
     } else {
-      const pathFromRoot = buildDirectory.replace(pathOffsetFromSourceRoot, "");
+      const pathFromRoot = buildDirectory.replace(pathOffsetFromSourceRoot, '');
       const modulePath = path.join(pathFromRoot, 'esm2015', `${flatModuleFileName}.js`);
       const pkgName = pathExistsSync(modulePath) ? packageNameWithoutScope : flatModuleFileName;
       this._makeEsmPackageNameVal = `${pkgName}.js`;

--- a/src/lib/model/ng-artifacts-factory.ts
+++ b/src/lib/model/ng-artifacts-factory.ts
@@ -1,8 +1,30 @@
+import { pathExistsSync } from 'fs-extra';
 import { path } from './../util/path';
 import { NgArtifacts } from './ng-artifacts';
 import { NgPackageData, SCOPE_NAME_SEPARATOR } from './ng-package-data';
 
 export class NgArtifactsFactory {
+
+  private _makeEsmPackageNameVal: string | undefined;
+  private _makeEsmPackageName(ngPkg: NgPackageData): string {
+    // The below is done in order to avoid same collisions in package name.
+    if (this._makeEsmPackageNameVal) {
+      return this._makeEsmPackageNameVal;
+    }
+
+    const { packageNameWithoutScope, flatModuleFileName, buildDirectory } = ngPkg;
+
+    if (packageNameWithoutScope === flatModuleFileName) {
+      this._makeEsmPackageNameVal = `${flatModuleFileName}.js`;
+    } else {
+      const modulePath = path.join(buildDirectory, 'esm2015', `${flatModuleFileName}.js`);
+      const pkgName = pathExistsSync(modulePath) ? packageNameWithoutScope : flatModuleFileName;
+      this._makeEsmPackageNameVal = `${pkgName}.js`;
+    }
+
+    return this._makeEsmPackageNameVal;
+  }
+
   private _makeUmdPackageName(ngPkg: NgPackageData): string {
     return ngPkg.packageNameWithoutScope.replace(SCOPE_NAME_SEPARATOR, '-') + '.umd.js';
   }
@@ -18,8 +40,8 @@ export class NgArtifactsFactory {
 
     return {
       main: path.join(buildDirectory, 'bundles', this._makeUmdPackageName(ngPkg)),
-      module: path.join(buildDirectory, 'esm5', `${flatModuleFileName}.js`),
-      es2015: path.join(buildDirectory, 'esm2015', `${flatModuleFileName}.js`),
+      module: path.join(buildDirectory, 'esm5', this._makeEsmPackageName(ngPkg)),
+      es2015: path.join(buildDirectory, 'esm2015', this._makeEsmPackageName(ngPkg)),
       typings: path.join(pathFromRoot, `${flatModuleFileName}.d.ts`),
       metadata: path.join(pathFromRoot, `${flatModuleFileName}.metadata.json`)
     }
@@ -31,8 +53,8 @@ export class NgArtifactsFactory {
 
     return {
       main: this._unixPathJoin(rootPathFromSelf, 'bundles', this._makeUmdPackageName(ngPkg)),
-      module: this._unixPathJoin(rootPathFromSelf, 'esm5', `${flatModuleFileName}.js`),
-      es2015: this._unixPathJoin(rootPathFromSelf, 'esm2015', `${flatModuleFileName}.js`),
+      module: this._unixPathJoin(rootPathFromSelf, 'esm5', this._makeEsmPackageName(ngPkg)),
+      es2015: this._unixPathJoin(rootPathFromSelf, 'esm2015', this._makeEsmPackageName(ngPkg)),
       typings: path.ensureUnixPath(`${flatModuleFileName}.d.ts`),
       metadata: path.ensureUnixPath(`${flatModuleFileName}.metadata.json`)
     }

--- a/src/lib/model/ng-artifacts-factory.ts
+++ b/src/lib/model/ng-artifacts-factory.ts
@@ -13,26 +13,28 @@ export class NgArtifactsFactory {
   }
 
   public calculateArtifactPathsForBuild(ngPkg: NgPackageData): NgArtifacts {
-    const pathFromRoot: string = path.resolve(ngPkg.buildDirectory, ngPkg.pathOffsetFromSourceRoot);
+    const { buildDirectory, pathOffsetFromSourceRoot, flatModuleFileName } = ngPkg;
+    const pathFromRoot: string = path.resolve(buildDirectory, pathOffsetFromSourceRoot);
 
     return {
-      main: path.join(ngPkg.buildDirectory,'bundles', this._makeUmdPackageName(ngPkg)),
-      module: path.join(ngPkg.buildDirectory, ngPkg.fullPackageName + '.es5.js'),
-      es2015: path.join(ngPkg.buildDirectory, ngPkg.fullPackageName + '.js'),
-      typings: path.join(pathFromRoot, ngPkg.flatModuleFileName + '.d.ts'),
-      metadata: path.join(pathFromRoot, ngPkg.flatModuleFileName + '.metadata.json')
+      main: path.join(buildDirectory, 'bundles', this._makeUmdPackageName(ngPkg)),
+      module: path.join(buildDirectory, 'esm5', `${flatModuleFileName}.js`),
+      es2015: path.join(buildDirectory, 'esm2015', `${flatModuleFileName}.js`),
+      typings: path.join(pathFromRoot, flatModuleFileName + '.d.ts'),
+      metadata: path.join(pathFromRoot, flatModuleFileName + '.metadata.json')
     }
   }
 
   public calculateArtifactPathsForPackageJson(ngPkg: NgPackageData): NgArtifacts {
-    const rootPathFromSelf: string = path.relative(ngPkg.sourcePath, ngPkg.rootSourcePath);
+    const { sourcePath, rootSourcePath, flatModuleFileName } = ngPkg;
+    const rootPathFromSelf: string = path.relative(sourcePath, rootSourcePath);
 
     return {
       main: this._unixPathJoin(rootPathFromSelf, 'bundles', this._makeUmdPackageName(ngPkg)),
-      module: this._unixPathJoin(rootPathFromSelf, `${ngPkg.fullPackageName}.es5.js`),
-      es2015: this._unixPathJoin(rootPathFromSelf, `${ngPkg.fullPackageName}.js`),
-      typings: path.ensureUnixPath(`${ngPkg.flatModuleFileName}.d.ts`),
-      metadata: path.ensureUnixPath(`${ngPkg.flatModuleFileName}.metadata.json`)
+      module: this._unixPathJoin(rootPathFromSelf, 'esm5', `${flatModuleFileName}.js`),
+      es2015: this._unixPathJoin(rootPathFromSelf, 'esm2015', `${flatModuleFileName}.js`),
+      typings: path.ensureUnixPath(`${flatModuleFileName}.d.ts`),
+      metadata: path.ensureUnixPath(`${flatModuleFileName}.metadata.json`)
     }
   }
 }

--- a/src/lib/steps/ngc.ts
+++ b/src/lib/steps/ngc.ts
@@ -23,7 +23,7 @@ async function prepareTsConfig(ngPkg: NgPackageData, outFile: string): Promise<v
     tsConfig['compilerOptions']['jsx'] = ngPkg.jsxConfig;
   }
 
-  await writeJson(outFile, tsConfig);
+  await writeJson(outFile, tsConfig, { spaces: 2 });
 }
 
 /**

--- a/src/lib/steps/package.ts
+++ b/src/lib/steps/package.ts
@@ -89,7 +89,7 @@ async function findSecondaryPackagePaths(rootPackage: NgPackageData): Promise<st
   const packagePaths: string[] = [];
 
   // read all directories (without recursion)
-  while(directoriesToSearch.length > 0) {
+  while (directoriesToSearch.length > 0) {
     const searchDirectory: string = directoriesToSearch.pop();
     const fileSystemEntries: string[] = await readdir(searchDirectory);
     let packageFileFound = false;
@@ -160,7 +160,7 @@ async function readRootPackage(filePath: string): Promise<NgPackageData> {
   const finalPackageConfig = merge(ngPkg, pkg.ngPackage, arrayMergeLogic);
   // make sure we provide default values for src and dest
   finalPackageConfig.src = finalPackageConfig.src || packageConfigurationDirectory;
-  finalPackageConfig.dest = finalPackageConfig.dest || path.resolve(packageConfigurationDirectory,'dist');
+  finalPackageConfig.dest = finalPackageConfig.dest || path.resolve(packageConfigurationDirectory, 'dist');
 
   return new NgPackageData(
     finalPackageConfig.src,
@@ -247,7 +247,7 @@ export async function writePackage(ngPkg: NgPackageData, packageArtifacts: NgArt
   log.debug('writePackage');
   const packageJson: any = await readJson(path.resolve(ngPkg.sourcePath, PACKAGE_JSON_FILE_NAME));
   // set additional properties
-  for(const fieldName in packageArtifacts) {
+  for (const fieldName in packageArtifacts) {
     packageJson[fieldName] = packageArtifacts[fieldName];
   }
 
@@ -257,5 +257,5 @@ export async function writePackage(ngPkg: NgPackageData, packageArtifacts: NgArt
   // this will not throw if ngPackage field does not exist
   delete packageJson.ngPackage;
 
-  await writeJson(path.resolve(ngPkg.destinationPath, PACKAGE_JSON_FILE_NAME), packageJson);
+  await writeJson(path.resolve(ngPkg.destinationPath, PACKAGE_JSON_FILE_NAME), packageJson, { spaces: 2 });
 }

--- a/src/lib/steps/sorcery.ts
+++ b/src/lib/steps/sorcery.ts
@@ -19,7 +19,7 @@ export async function remapSourceMap(sourceFile: string): Promise<void> {
   // Once sorcery loads the chain of sourcemaps, the new sourcemap will be written asynchronously.
   const chain = await sorcery.load(sourceFile);
   if (!chain) {
-    throw new Error('Failed to load sourceMap chain for ' + sourceFile);
+    throw new Error(`Failed to load sourceMap chain for ${sourceFile}`);
   }
 
   await chain.write(opts);

--- a/src/lib/steps/transfer.ts
+++ b/src/lib/steps/transfer.ts
@@ -1,6 +1,5 @@
 import { NgPackageData, SCOPE_NAME_SEPARATOR } from './../model/ng-package-data';
 import { copyFiles } from './../util/copy';
-import * as path from 'path';
 
 /**
  * Copies compiled source files from the build directory to the correct locations in the destination directory.

--- a/src/lib/steps/transfer.ts
+++ b/src/lib/steps/transfer.ts
@@ -9,15 +9,10 @@ import * as path from 'path';
  * @param baseBuildPath Path to where the source files are staged.
  */
 export async function copySourceFilesToDestination(ngPkg: NgPackageData, baseBuildPath: string): Promise<void> {
-  const separatorIndex: number = ngPkg.fullPackageName.lastIndexOf(SCOPE_NAME_SEPARATOR);
-  if (separatorIndex > -1) {
-    const packageNameWithoutEndPart: string = ngPkg.fullPackageName.substring(0, separatorIndex);
-    const destinationPath: string = path.resolve(ngPkg.rootDestinationPath, packageNameWithoutEndPart);
-    await copyFiles(`${ngPkg.buildDirectory}/${packageNameWithoutEndPart}/**/*.{js,js.map}`, destinationPath);
-  } else {
-    await copyFiles(`${ngPkg.buildDirectory}/${ngPkg.fullPackageName}*.{js,js.map}`, ngPkg.rootDestinationPath);
-  }
-
-  await copyFiles(`${ngPkg.buildDirectory}/bundles/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/bundles`);
-  await copyFiles(`${baseBuildPath}/**/*.{d.ts,metadata.json}`, ngPkg.destinationPath);
+  await Promise.all([
+    copyFiles(`${ngPkg.buildDirectory}/bundles/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/bundles`),
+    copyFiles(`${ngPkg.buildDirectory}/esm5/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/esm5`),
+    copyFiles(`${ngPkg.buildDirectory}/esm2015/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/esm2015`),
+    copyFiles(`${baseBuildPath}/**/*.{d.ts,metadata.json}`, ngPkg.destinationPath)
+  ]);
 }

--- a/src/lib/steps/tsc.ts
+++ b/src/lib/steps/tsc.ts
@@ -6,7 +6,7 @@ import {
   transpileModule,
   CompilerOptions
 } from 'typescript';
-import { readFile, writeFile } from 'fs-extra';
+import { readFile, outputJson, outputFile as fsOutputFile } from 'fs-extra';
 import { debug } from '../util/log';
 
 /**
@@ -23,7 +23,8 @@ export async function downlevelWithTsc(inputFile: string, outputFile: string): P
     target: ScriptTarget.ES5,
     module: ModuleKind.ES2015,
     allowJs: true,
-    sourceMap: true
+    sourceMap: true,
+    mapRoot: path.dirname(inputFile)
   };
   const transpiled: TranspileOutput = transpileModule(trimSourceMap(input.toString()), {
     fileName: path.basename(outputFile),
@@ -36,11 +37,10 @@ export async function downlevelWithTsc(inputFile: string, outputFile: string): P
   sourceMap['sources'] = [path.basename(inputFile)];
 
   await Promise.all([
-    writeFile(outputFile, transpiled.outputText),
-    writeFile(`${outputFile}.map`, JSON.stringify(sourceMap))
+    fsOutputFile(outputFile, transpiled.outputText),
+    outputJson(`${outputFile}.map`, sourceMap, { spaces: 2 })
   ]);
 };
-
 
 const REGEXP = /\/\/# sourceMappingURL=.*\.js\.map/;
 const trimSourceMap = (fileContent: string): string => {

--- a/src/lib/steps/uglify.ts
+++ b/src/lib/steps/uglify.ts
@@ -29,7 +29,7 @@ export async function minifyJsFile(inputPath: string): Promise<string> {
   });
 
   if (result.warnings) {
-    for(const warningMessage of result.warnings) {
+    for (const warningMessage of result.warnings) {
       warn(warningMessage);
     }
   }
@@ -38,7 +38,9 @@ export async function minifyJsFile(inputPath: string): Promise<string> {
     throw result.error;
   }
 
-  await writeFile(outputPath, result.code);
-  await writeFile(sourcemapOut, result.map);
+  await Promise.all([
+    writeFile(outputPath, result.code),
+    writeFile(sourcemapOut, result.map)
+  ]);
   return outputPath;
 }

--- a/src/lib/util/json.ts
+++ b/src/lib/util/json.ts
@@ -21,7 +21,7 @@ export async function modifyJsonFiles(globPattern: string, modifyFn: (jsonObj: a
     fileNames.map(async (fileName: string): Promise<void> => {
       const fileContent: any = await tryReadJson(fileName);
       const modified = modifyFn(fileContent);
-      await writeJson(fileName, modified);
+      await writeJson(fileName, modified, { spaces: 2 });
     }
   ));
 }


### PR DESCRIPTION
Fixes #257 #319  #321 

- FESM5 and FES2015 modules are not into seperate directories `/esm5` and `/esm2015` respectively.
- Secondary entry points output files are longer nested under
`/secondary-package`, only typings  are.

More info:
https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview

## I'm submitting a...

```
[ ] Bug Fix
[X] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
Align with Angular Package Format v5.0
https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview

## Does this PR introduce a breaking change?

```
[] Yes
[X] No
```