### PR TITLE
refactor: async disk flushes and create const for dirnames

### DIFF
--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -22,7 +22,7 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
   log.info(`Generating bundle for ${ngPkg.fullPackageName}`);
   const artifactFactory = new NgArtifactsFactory();
   const baseBuildPath = `${ngPkg.buildDirectory}/ts${ngPkg.pathOffsetFromSourceRoot}`;
-  const artifactPaths = artifactFactory.calculateArtifactPathsForBuild(ngPkg);
+  const artifactPaths: NgArtifacts = artifactFactory.calculateArtifactPathsForBuild(ngPkg);
 
   // 0. CLEAN BUILD DIRECTORY
   log.info('Cleaning bundle build directory');
@@ -82,7 +82,7 @@ export async function generateNgBundle(ngPkg: NgPackageData): Promise<void> {
 
   // 9. WRITE PACKAGE.JSON and OTHER DOC FILES
   log.info('Writing package metadata');
-  const packageJsonArtifactPaths = artifactFactory.calculateArtifactPathsForPackageJson(ngPkg);
+  const packageJsonArtifactPaths: NgArtifacts = artifactFactory.calculateArtifactPathsForPackageJson(ngPkg);
   await writePackage(ngPkg, packageJsonArtifactPaths);
 
   log.success(`Built Angular bundle for ${ngPkg.fullPackageName}`);

--- a/src/lib/model/ng-artifacts-factory.ts
+++ b/src/lib/model/ng-artifacts-factory.ts
@@ -3,6 +3,10 @@ import { path } from './../util/path';
 import { NgArtifacts } from './ng-artifacts';
 import { NgPackageData, SCOPE_NAME_SEPARATOR } from './ng-package-data';
 
+export const ESM2015_DIR_NAME = 'esm2015';
+export const ESM5_DIR_NAME = 'esm5';
+export const BUNDLES_DIR_NAME = 'bundles';
+
 export class NgArtifactsFactory {
 
   private _makeEsmPackageNameVal: string | undefined;
@@ -18,7 +22,7 @@ export class NgArtifactsFactory {
       this._makeEsmPackageNameVal = `${flatModuleFileName}.js`;
     } else {
       const pathFromRoot = buildDirectory.replace(pathOffsetFromSourceRoot, '');
-      const modulePath = path.join(pathFromRoot, 'esm2015', `${flatModuleFileName}.js`);
+      const modulePath = path.join(pathFromRoot, ESM2015_DIR_NAME, `${flatModuleFileName}.js`);
       const pkgName = pathExistsSync(modulePath) ? packageNameWithoutScope : flatModuleFileName;
       this._makeEsmPackageNameVal = `${pkgName}.js`;
     }
@@ -40,9 +44,9 @@ export class NgArtifactsFactory {
     const pathFromRoot = path.resolve(buildDirectory, pathOffsetFromSourceRoot);
 
     return {
-      main: path.join(buildDirectory, 'bundles', this._makeUmdPackageName(ngPkg)),
-      module: path.join(buildDirectory, 'esm5', this._makeEsmPackageName(ngPkg)),
-      es2015: path.join(buildDirectory, 'esm2015', this._makeEsmPackageName(ngPkg)),
+      main: path.join(buildDirectory, BUNDLES_DIR_NAME, this._makeUmdPackageName(ngPkg)),
+      module: path.join(buildDirectory, ESM5_DIR_NAME, this._makeEsmPackageName(ngPkg)),
+      es2015: path.join(buildDirectory, ESM5_DIR_NAME, this._makeEsmPackageName(ngPkg)),
       typings: path.join(pathFromRoot, `${flatModuleFileName}.d.ts`),
       metadata: path.join(pathFromRoot, `${flatModuleFileName}.metadata.json`)
     }
@@ -53,9 +57,9 @@ export class NgArtifactsFactory {
     const rootPathFromSelf = path.relative(sourcePath, rootSourcePath);
 
     return {
-      main: this._unixPathJoin(rootPathFromSelf, 'bundles', this._makeUmdPackageName(ngPkg)),
-      module: this._unixPathJoin(rootPathFromSelf, 'esm5', this._makeEsmPackageName(ngPkg)),
-      es2015: this._unixPathJoin(rootPathFromSelf, 'esm2015', this._makeEsmPackageName(ngPkg)),
+      main: this._unixPathJoin(rootPathFromSelf, BUNDLES_DIR_NAME, this._makeUmdPackageName(ngPkg)),
+      module: this._unixPathJoin(rootPathFromSelf, ESM5_DIR_NAME, this._makeEsmPackageName(ngPkg)),
+      es2015: this._unixPathJoin(rootPathFromSelf, ESM5_DIR_NAME, this._makeEsmPackageName(ngPkg)),
       typings: path.ensureUnixPath(`${flatModuleFileName}.d.ts`),
       metadata: path.ensureUnixPath(`${flatModuleFileName}.metadata.json`)
     }

--- a/src/lib/steps/transfer.ts
+++ b/src/lib/steps/transfer.ts
@@ -1,5 +1,6 @@
 import { NgPackageData, SCOPE_NAME_SEPARATOR } from './../model/ng-package-data';
 import { copyFiles } from './../util/copy';
+import { ESM5_DIR_NAME, ESM2015_DIR_NAME, BUNDLES_DIR_NAME } from '../model/ng-artifacts-factory';
 
 /**
  * Copies compiled source files from the build directory to the correct locations in the destination directory.
@@ -8,10 +9,8 @@ import { copyFiles } from './../util/copy';
  * @param baseBuildPath Path to where the source files are staged.
  */
 export async function copySourceFilesToDestination(ngPkg: NgPackageData, baseBuildPath: string): Promise<void> {
-  await Promise.all([
-    copyFiles(`${ngPkg.buildDirectory}/bundles/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/bundles`),
-    copyFiles(`${ngPkg.buildDirectory}/esm5/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/esm5`),
-    copyFiles(`${ngPkg.buildDirectory}/esm2015/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/esm2015`),
-    copyFiles(`${baseBuildPath}/**/*.{d.ts,metadata.json}`, ngPkg.destinationPath)
-  ]);
+  await copyFiles(`${ngPkg.buildDirectory}/${BUNDLES_DIR_NAME}/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/${BUNDLES_DIR_NAME}`);
+  await copyFiles(`${ngPkg.buildDirectory}/${ESM5_DIR_NAME}/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/${ESM5_DIR_NAME}`);
+  await copyFiles(`${ngPkg.buildDirectory}/${ESM2015_DIR_NAME}/**/*.{js,js.map}`, `${ngPkg.rootDestinationPath}/${ESM2015_DIR_NAME}`);
+  await copyFiles(`${baseBuildPath}/**/*.{d.ts,metadata.json}`, ngPkg.destinationPath);
 }

--- a/src/lib/steps/uglify.ts
+++ b/src/lib/steps/uglify.ts
@@ -38,9 +38,8 @@ export async function minifyJsFile(inputPath: string): Promise<string> {
     throw result.error;
   }
 
-  await Promise.all([
-    writeFile(outputPath, result.code),
-    writeFile(sourcemapOut, result.map)
-  ]);
+  await writeFile(outputPath, result.code);
+  await writeFile(sourcemapOut, result.map);
+
   return outputPath;
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

following @DavidParks8 comments in https://github.com/dherges/ng-packagr/pull/322#pullrequestreview-79658111

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
