### PR TITLE
refactor: add const for output folders name

### DIFF
--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { NgArtefacts } from './domain/ng-artefacts';
-import { NgPackageData } from './model/ng-package-data';
+import { NgPackageData, ESM2015_FOLDER, ESM5_FOLDER, BUNDLES_FOLDER } from './model/ng-package-data';
 import { writePackage } from './steps/package';
 import { processAssets } from './steps/assets';
 import { ngc, prepareTsConfig, collectTemplateAndStylesheetFiles, inlineTemplatesAndStyles } from './steps/ngc';
@@ -51,7 +51,7 @@ export async function transformSources(ngPkg: NgPackageData): Promise<void> {
 
   // 3. FESM15: ROLLUP
   log.info('Bundling to FESM15');
-  const fesm15File = path.resolve(ngPkg.buildDirectory, 'esm2015', ngPkg.esmPackageName);
+  const fesm15File = path.resolve(ngPkg.buildDirectory, ESM2015_FOLDER, ngPkg.esmPackageName);
   await rollup({
     moduleName: ngPkg.moduleName,
     entry: tsOutput.js,
@@ -63,13 +63,13 @@ export async function transformSources(ngPkg: NgPackageData): Promise<void> {
 
   // 4. FESM5: TSC
   log.info('Bundling to FESM5');
-  const fesm5File = path.resolve(ngPkg.buildDirectory, 'esm5', ngPkg.esmPackageName);
+  const fesm5File = path.resolve(ngPkg.buildDirectory, ESM5_FOLDER, ngPkg.esmPackageName);
   await downlevelWithTsc(fesm15File, fesm5File);
   await remapSourceMap(fesm5File);
 
   // 5. UMD: ROLLUP
   log.info('Bundling to UMD');
-  const umdFile = path.resolve(ngPkg.buildDirectory, 'bundles', ngPkg.umdPackageName);
+  const umdFile = path.resolve(ngPkg.buildDirectory, BUNDLES_FOLDER, ngPkg.umdPackageName);
   await rollup({
     moduleName: ngPkg.moduleName,
     entry: fesm5File,
@@ -92,9 +92,9 @@ export async function transformSources(ngPkg: NgPackageData): Promise<void> {
   log.info('Writing package metadata');
   const rootPathFromSelf: string = path.relative(ngPkg.sourcePath, ngPkg.rootSourcePath);
   await writePackage(ngPkg, {
-    main: ensureUnixPath(path.join(rootPathFromSelf, 'bundles', ngPkg.umdPackageName)),
-    module: ensureUnixPath(path.join(rootPathFromSelf, 'esm5', ngPkg.esmPackageName)),
-    es2015: ensureUnixPath(path.join(rootPathFromSelf, 'esm2015', ngPkg.esmPackageName)),
+    main: ensureUnixPath(path.join(rootPathFromSelf, BUNDLES_FOLDER, ngPkg.umdPackageName)),
+    module: ensureUnixPath(path.join(rootPathFromSelf, ESM5_FOLDER, ngPkg.esmPackageName)),
+    es2015: ensureUnixPath(path.join(rootPathFromSelf, ESM2015_FOLDER, ngPkg.esmPackageName)),
     typings: ensureUnixPath(`${ngPkg.flatModuleFileName}.d.ts`),
     metadata: ensureUnixPath(`${ngPkg.flatModuleFileName}.metadata.json`)
   });

--- a/src/lib/model/ng-package-data.ts
+++ b/src/lib/model/ng-package-data.ts
@@ -6,6 +6,10 @@ export const SCOPE_PREFIX = '@';
 export const SCOPE_NAME_SEPARATOR = '/';
 export const DEFAULT_BUILD_FOLDER = '.ng_pkg_build';
 
+export const ESM2015_FOLDER = 'esm2015';
+export const ESM5_FOLDER = 'esm5';
+export const BUNDLES_FOLDER = 'bundles';
+
 // TODO: this is obviously stuff derived from 'ng-package.json'
 // TODO: use @ngtools/json-schema to parse the JSON configuration
 export class NgPackageData {

--- a/src/lib/steps/transfer.ts
+++ b/src/lib/steps/transfer.ts
@@ -1,6 +1,13 @@
-import { NgPackageData, SCOPE_NAME_SEPARATOR } from './../model/ng-package-data';
-import { copyFiles } from './../util/copy';
+
 import * as path from 'path';
+import {
+  NgPackageData,
+  SCOPE_NAME_SEPARATOR,
+  ESM2015_FOLDER,
+  ESM5_FOLDER,
+  BUNDLES_FOLDER
+} from './../model/ng-package-data';
+import { copyFiles } from './../util/copy';
 
 /**
  * Copies compiled source files from the build directory to the correct locations in the destination directory.
@@ -8,12 +15,12 @@ import * as path from 'path';
  * @param ngPkg Angular package data.
  */
 export async function copySourceFilesToDestination(ngPkg: NgPackageData): Promise<void> {
-  await copyFiles(`${ngPkg.buildDirectory}/bundles/**/*.{js,js.map}`,
-    path.resolve(ngPkg.rootDestinationPath, 'bundles'));
-  await copyFiles(`${ngPkg.buildDirectory}/esm5/**/*.{js,js.map}`,
-    path.resolve(ngPkg.rootDestinationPath, 'esm5'))
-  await copyFiles(`${ngPkg.buildDirectory}/esm2015/**/*.{js,js.map}`,
-    path.resolve(ngPkg.rootDestinationPath, 'esm2015'))
+  await copyFiles(`${ngPkg.buildDirectory}/${BUNDLES_FOLDER}/**/*.{js,js.map}`,
+    path.resolve(ngPkg.rootDestinationPath, BUNDLES_FOLDER));
+  await copyFiles(`${ngPkg.buildDirectory}/${ESM5_FOLDER}/**/*.{js,js.map}`,
+    path.resolve(ngPkg.rootDestinationPath, ESM5_FOLDER))
+  await copyFiles(`${ngPkg.buildDirectory}/${ESM2015_FOLDER}/**/*.{js,js.map}`,
+    path.resolve(ngPkg.rootDestinationPath, ESM2015_FOLDER))
   await copyFiles(`${ngPkg.buildDirectory}/**/*.{d.ts,metadata.json}`,
     ngPkg.destinationPath);
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

following @DavidParks8 comments in https://github.com/dherges/ng-packagr/pull/322#discussion_r153625248

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
