### PR TITLE
feat: add ability to override tsconfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       # Run the ci build
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test
-      # Store artefacts on circle
+      # Store artifacts on circle
       - run: mkdir -p /tmp/samples
       - run: cp -r --parents integration/samples/**/dist /tmp/samples
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,7 @@ Secondary entrypoints – such as `@angular/core/testing`, `@angular/common/http
 
 ### Bug Fixes
 
-* include `package.schema.json` in dist artefacts and npm package ([e660545](https://github.com/dherges/ng-packagr/commit/e660545))
+* include `package.schema.json` in dist artifacts and npm package ([e660545](https://github.com/dherges/ng-packagr/commit/e660545))
 
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,43 @@ To configure with a `package.json`, put the configuration in the `ngPackage` cus
 
 Note: referencing the `$schema` enables JSON editing support (auto-completion for configuration) in IDEs like [VSCode](https://github.com/Microsoft/vscode).
 
+To configure with a custom `tsconfig` file, put the path relative to your source path in the `tsconfig` field:
+
+```json
+{
+  "$schema": "./node_modules/ng-packagr/package.schema.json",
+  "ngPackage": {
+    "tsconfig": "my-custom-tsconfig.json",
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
+  }
+}
+```
+
+> Note: Many fields are not overridable in order to adhere to the angular package format. Any attempt to edit the following fields will have no effect:
+> - flatModuleId
+> - flatModuleOutFile
+> - basePath
+> - baseUrl
+> - outDir
+> - genDir
+> - target
+> - module
+> - moduleResolution
+> - declaration
+> - sourceMap
+> - inlineSources
+> - inlineSourceMap
+> - mapRoot
+> - allowSyntheticDefaultImports
+> - skipLibCheck
+> - emitDecoratorMetadata
+> - experimentalDecorators
+> - annotateForClosureCompiler
+> - skipTemplateCodegen
+> - strictMetadataEmit
+
 #### Secondary Entry Points
 
 Beside the primary entry point, a package can contain one or more secondary entry points (e.g. `@angular/core/testing`, `@angular/cdk/a11y`, …).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -8,12 +8,12 @@ Design Doc: "ng-packagr"
 
 Design choices of `ng-packagr` from the view of library authors and library consumers.
 
-The motivation is to help authors write libraries and generate the expected, distribution-ready artefacts for library consumers.
+The motivation is to help authors write libraries and generate the expected, distribution-ready artifacts for library consumers.
 
 
-### Build artefacts
+### Build artifacts
 
-According to [Angular Package Format](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview), there need to be the following build artefacts:
+According to [Angular Package Format](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview), there need to be the following build artifacts:
 
 * FESM2015 Bundle: `@<prefix>/<name>.js` in ES2015 syntax and ES2015 module format, a so-called Flat ECMAScript Module. It is referenced in the `es2015` property of `package.json`.
 * FESM5 Bundle: `@<prefix>/<name>.es5.js` in ES5 syntax and ES2015 module format, a so-called Flat ECMAScript Module (ESM, or FESM5, or FESM2014). It is referenced in the `module` property of `package.json`.
@@ -40,11 +40,11 @@ This pattern is also a recommended approach for building flat modules.
 ### Package definition and library metadata
 
 For consumers of a library, the package definition is provided in a `package.json` file, including `peerDependencies`, `name`, `version`, etc.
-Most important, the build artefacts (see above) are referenced in `package.json`.
-In this way, library consumers and build tools will pick-up the correct build artefact of the library for compiling their applications.
+Most important, the build artifacts (see above) are referenced in `package.json`.
+In this way, library consumers and build tools will pick-up the correct build artifact of the library for compiling their applications.
 
 **DO**: `ng-packagr` generates a `package.json` for library consumers.
-To do so, it needs an input `package.json` that includes basic information like `name` and `version` and it will add references to the auto-generated build artefacts.
+To do so, it needs an input `package.json` that includes basic information like `name` and `version` and it will add references to the auto-generated build artifacts.
 
 
 A `package.json` also includes information needed to distribute and publish the library.

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -8,7 +8,7 @@ Develop Guideline
 $ yarn release
 ```
 
-This builds the tool, cuts a release, and copies the distributable artefacts to `dist`.
+This builds the tool, cuts a release, and copies the distributable artifacts to `dist`.
 When cutting the release, it uses the [standard-version workflow](https://github.com/conventional-changelog/standard-version).
 The release is then ready to be published:
 
@@ -19,7 +19,7 @@ $ git push --follow-tags origin master
 This pushes branch `master` and the `v{x}.{y}.{z}` tag to the GitHub repository, thus triggering a build on Circle CI.
 Circle CI will checkout the Git tag, build from sources (again), and automatically publish to the npm registry.
 
-If neccessary, distributable artefacts can be created and published by hand:
+If neccessary, distributable artifacts can be created and published by hand:
 
 ```bash
 $ yarn pack dist

--- a/integration/consumer.sh
+++ b/integration/consumer.sh
@@ -5,19 +5,22 @@ parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$parent_path"
 echo "Running consumer builds in $parent_path"
 
-# Prepare 'sample-custom'
-pushd samples/custom/dist
-yarn unlink || true
-yarn link
-popd
+# Link a library
+link(){
+   # libPath stores $1 argument passed to link()
+   libPath=$1
+   echo "Prepare '$libPath'"
+   pushd $libPath
+   # never fail unlink for the case where nothing has been linked before
+   yarn unlink || true
+   yarn link
+   popd
+}
 
-# Prepare '@sample/material'
-pushd samples/material/dist
-yarn unlink || true
-yarn link
-popd
+link samples/custom/dist
+link samples/material/dist
 
-# Build ng cli app
+echo "Build ng cli app"
 pushd consumers/ng-cli
 yarn install
 yarn link sample-custom

--- a/integration/samples/custom/specs/es5-api.ts
+++ b/integration/samples/custom/specs/es5-api.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe(`sample-custom`, () => {
-
   describe(`esm5/sample-custom.js`, () => {
     let API;
     before(() => {
@@ -16,6 +15,11 @@ describe(`sample-custom`, () => {
 
     it(`should not export InternalService`, () => {
       expect(API['InternalService']).to.be.undefined;
+    });
+
+    it(`should not alter BazComponent selector`, () => {
+      const moduleText: string = fs.readFileSync('./integration/samples/custom/dist/esm5/sample-custom.js').toString();
+      expect(/selector: 'custom-baz',\s*template: "<h1>Baz!</gm.test(moduleText)).to.equal(true);
     });
 
   });

--- a/integration/samples/tsconfig/.browserslistrc
+++ b/integration/samples/tsconfig/.browserslistrc
@@ -1,0 +1,3 @@
+last 2 Chrome versions
+iOS > 10
+Safari > 10

--- a/integration/samples/tsconfig/README.md
+++ b/integration/samples/tsconfig/README.md
@@ -1,0 +1,4 @@
+Sample library: Configuration of custom tsconfig
+======================================
+
+The configuration in this sample resides inside `package.json`.

--- a/integration/samples/tsconfig/baz/baz.component.html
+++ b/integration/samples/tsconfig/baz/baz.component.html
@@ -1,0 +1,1 @@
+<h1 class="baz">baz!</h1>

--- a/integration/samples/tsconfig/baz/baz.component.scss
+++ b/integration/samples/tsconfig/baz/baz.component.scss
@@ -1,0 +1,5 @@
+@import '~node-sass/test/fixtures/include-files/file-not-processed-by-loader';
+
+.baz {
+    color: $variable-defined-by-file-not-processed-by-loader;
+}

--- a/integration/samples/tsconfig/baz/baz.component.ts
+++ b/integration/samples/tsconfig/baz/baz.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'baz-component',
+  templateUrl: './baz.component.html',
+  styleUrls: ['./baz.component.scss']
+})
+export class BazComponent {
+  public computePower(): number {
+    return 1 ** 2; // this operator does not exist in es2015
+  }
+}

--- a/integration/samples/tsconfig/package.json
+++ b/integration/samples/tsconfig/package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../src/package.schema.json",
+  "name": "@sample/tsconfig",
+  "description": "A sample library with custom tsconfig",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  },
+  "ngPackage": {
+    "tsconfig": "./tsconfig.test.json",
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
+  }
+}

--- a/integration/samples/tsconfig/public_api.ts
+++ b/integration/samples/tsconfig/public_api.ts
@@ -1,0 +1,2 @@
+export * from './baz/baz.component';
+export * from './ui-lib.module';

--- a/integration/samples/tsconfig/tsconfig.test.json
+++ b/integration/samples/tsconfig/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "es2017"
+    ]
+  }
+}

--- a/integration/samples/tsconfig/ui-lib.module.ts
+++ b/integration/samples/tsconfig/ui-lib.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { BazComponent } from './baz/baz.component';
+
+@NgModule({
+  declarations: [
+    BazComponent,
+  ],
+  exports: [
+    BazComponent,
+  ]
+})
+export class UiLibModule {}

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { NgArtefacts } from './domain/ng-artefacts';
+import { NgArtifacts } from './domain/ng-artifacts';
 import { NgPackageData } from './model/ng-package-data';
 import { writePackage } from './steps/package';
 import { processAssets } from './steps/assets';
@@ -20,32 +20,32 @@ import { rimraf } from './util/rimraf';
  */
 export async function transformSources(ngPkg: NgPackageData): Promise<void> {
   log.info(`Building from sources for entry point '${ngPkg.fullPackageName}'`);
-  const artefacts = new NgArtefacts(ngPkg);
+  const artifacts = new NgArtifacts(ngPkg);
 
   // 0. CLEAN BUILD DIRECTORY
   log.info('Cleaning build directory');
   await rimraf(ngPkg.buildDirectory);
 
   // 0. TWO-PASS TSC TRANSFORMATION
-  artefacts.tsConfig = prepareTsConfig(ngPkg);
+  artifacts.tsConfig = prepareTsConfig(ngPkg);
 
   // First pass: collect templateUrl and styleUrls referencing source files.
   log.info('Extracting templateUrl and styleUrls');
-  const result = collectTemplateAndStylesheetFiles(artefacts.tsConfig, artefacts);
+  const result = collectTemplateAndStylesheetFiles(artifacts.tsConfig, artifacts);
   result.dispose();
 
   // Then, process assets keeping transformed contents in memory.
   log.info('Processing assets');
-  await processAssets(artefacts, ngPkg);
+  await processAssets(artifacts, ngPkg);
 
   // Second pass: inline templateUrl and styleUrls
   log.info('Inlining templateUrl and styleUrls');
-  artefacts.tsSources = inlineTemplatesAndStyles(artefacts.tsConfig, artefacts);
+  artifacts.tsSources = inlineTemplatesAndStyles(artifacts.tsConfig, artifacts);
 
   // 1. NGC
   log.info('Compiling with ngc');
-  const tsOutput = await ngc(ngPkg, artefacts.tsSources, artefacts.tsConfig);
-  artefacts.tsSources.dispose();
+  const tsOutput = await ngc(ngPkg, artifacts.tsSources, artifacts.tsConfig);
+  artifacts.tsSources.dispose();
 
   // await remapSourceMap(tsOutput.js);
 

--- a/src/lib/domain/ng-artifacts.ts
+++ b/src/lib/domain/ng-artifacts.ts
@@ -4,12 +4,12 @@ import { NgPackageData } from '../model/ng-package-data';
 import { TsConfig } from '../steps/ngc';
 
 /**
- * Build artefacts generated for an Angular library.
+ * Build artifacts generated for an Angular library.
  *
- * The artefacts include distribution-ready 'binaries' as well as temporary files and
+ * The artifacts include distribution-ready 'binaries' as well as temporary files and
  * intermediate build output.
  */
-export class NgArtefacts {
+export class NgArtifacts {
 
   /** Directory for temporary files */
   public stageDir: string;

--- a/src/lib/model/ng-package-data.ts
+++ b/src/lib/model/ng-package-data.ts
@@ -21,6 +21,7 @@ export class NgPackageData {
   public readonly buildDirectory: string;
   public readonly libExternals: any;
   public readonly jsxConfig?: string;
+  public readonly tsconfigPath: string;
 
   constructor(
     /**
@@ -44,6 +45,9 @@ export class NgPackageData {
     this.destinationPath = rootDestinationPath + this.pathOffsetFromSourceRoot;
     this.fullPackageName = ensureUnixPath(rootPackageName + this.pathOffsetFromSourceRoot);
     this.moduleName = this.fullPackageName.replace(SCOPE_PREFIX, '').split(SCOPE_NAME_SEPARATOR).join('.');
+    this.tsconfigPath = ngPackageConfig.tsconfig
+      ? path.resolve(this.sourcePath, ngPackageConfig.tsconfig)
+      : path.resolve(__dirname, '..', 'conf', 'tsconfig.ngc.json');
 
     if (this.fullPackageName.startsWith(SCOPE_PREFIX)) {
       const firstSeparatorIndex: number = this.fullPackageName.indexOf(SCOPE_NAME_SEPARATOR);

--- a/src/lib/steps/assets.ts
+++ b/src/lib/steps/assets.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { readFile } from 'fs-extra';
-import { NgArtefacts } from '../domain/ng-artefacts';
+import { NgArtifacts } from '../domain/ng-artifacts';
 import { NgPackageData } from '../model/ng-package-data';
 import * as log from '../util/log';
 
@@ -13,10 +13,10 @@ import * as less from 'less';
 import * as stylus from 'stylus';
 
 export const processAssets =
-  async (artefacts: NgArtefacts, pkg: NgPackageData): Promise<NgArtefacts> => {
+  async (artifacts: NgArtifacts, pkg: NgPackageData): Promise<NgArtifacts> => {
     // process templates
     const templates = await Promise.all(
-      artefacts.templates()
+      artifacts.templates()
         .map(async (template) => {
           return {
             name: template,
@@ -25,12 +25,12 @@ export const processAssets =
         })
     );
     templates.forEach((template) => {
-      artefacts.template(template.name, template.content);
+      artifacts.template(template.name, template.content);
     });
 
     // TODO: process stylesheets
     const stylesheets = await Promise.all(
-      artefacts.stylesheets()
+      artifacts.stylesheets()
         .map(async (stylesheet) => {
           return {
             name: stylesheet,
@@ -39,10 +39,10 @@ export const processAssets =
         })
     );
     stylesheets.forEach((stylesheet) => {
-      artefacts.stylesheet(stylesheet.name, stylesheet.content);
+      artifacts.stylesheet(stylesheet.name, stylesheet.content);
     });
 
-    return Promise.resolve(artefacts);
+    return Promise.resolve(artifacts);
   }
 
 /**

--- a/src/lib/steps/ngc.ts
+++ b/src/lib/steps/ngc.ts
@@ -4,7 +4,7 @@ import * as ng from '@angular/compiler-cli';
 // XX: has or is using name 'ParsedConfiguration' ... but cannot be named
 import { ParsedConfiguration } from '@angular/compiler-cli';
 import * as ts from 'typescript';
-import { NgArtefacts } from '../domain/ng-artefacts';
+import { NgArtifacts } from '../domain/ng-artifacts';
 import { NgPackageData } from '../model/ng-package-data';
 import * as log from '../util/log';
 import { componentTransformer } from '../util/ts-transformers';
@@ -95,13 +95,13 @@ const compilerHostFromTransformation =
 
 /** Extracts templateUrl and styleUrls from `@Component({..})` decorators. */
 export const collectTemplateAndStylesheetFiles =
-  (tsConfig: TsConfig, artefacts: NgArtefacts): ts.TransformationResult<ts.SourceFile> => {
+  (tsConfig: TsConfig, artifacts: NgArtifacts): ts.TransformationResult<ts.SourceFile> => {
     const collector = componentTransformer({
       templateProcessor: (a, b, templateFilePath) => {
-        artefacts.template(templateFilePath, null);
+        artifacts.template(templateFilePath, null);
       },
       stylesheetProcessor: (a, b, styleFilePath) => {
-        artefacts.stylesheet(styleFilePath, null);
+        artifacts.stylesheet(styleFilePath, null);
       }
     });
 
@@ -113,11 +113,11 @@ export const collectTemplateAndStylesheetFiles =
 
 /** Transforms templateUrl and styleUrls in `@Component({..})` decorators. */
 export const inlineTemplatesAndStyles =
-  (tsConfig: TsConfig, artefacts: NgArtefacts): ts.TransformationResult<ts.SourceFile> => {
-    // inline contents from artefacts set (generated in a previous step)
+  (tsConfig: TsConfig, artifacts: NgArtifacts): ts.TransformationResult<ts.SourceFile> => {
+    // inline contents from artifacts set (generated in a previous step)
     const transformer = componentTransformer({
-      templateProcessor: (a, b, templateFilePath) => artefacts.template(templateFilePath) || '',
-      stylesheetProcessor: (a, b, styleFilePath) => artefacts.stylesheet(styleFilePath) || ''
+      templateProcessor: (a, b, templateFilePath) => artifacts.template(templateFilePath) || '',
+      stylesheetProcessor: (a, b, styleFilePath) => artifacts.stylesheet(styleFilePath) || ''
     });
 
     return transformSources(

--- a/src/lib/steps/ngc.ts
+++ b/src/lib/steps/ngc.ts
@@ -17,8 +17,10 @@ export const prepareTsConfig =
   (ngPkg: NgPackageData): TsConfig => {
     const basePath = ngPkg.sourcePath;
 
+    log.debug(`Loading tsconfig from ${ngPkg.tsconfigPath}`);
     // Read the default configuration and overwrite package-specific options
-    const tsConfig = ng.readConfiguration(path.resolve(__dirname, '..', 'conf', 'tsconfig.ngc.json'));
+    const tsConfig: TsConfig = ng.readConfiguration(ngPkg.tsconfigPath);
+
     tsConfig.rootNames = [ path.resolve(basePath, ngPkg.entryFile) ];
     tsConfig.options.flatModuleId = ngPkg.fullPackageName
     tsConfig.options.flatModuleOutFile = `${ngPkg.flatModuleFileName}.js`;
@@ -26,6 +28,31 @@ export const prepareTsConfig =
     tsConfig.options.baseUrl = basePath;
     tsConfig.options.outDir = ngPkg.buildDirectory; // path.resolve(basePath, '.ng_pkg_build');
     tsConfig.options.genDir = ngPkg.buildDirectory; // path.resolve(basePath, '.ng_pkg_build');
+    tsConfig.options.outFile = undefined;
+    tsConfig.options.target = ts.ScriptTarget.ES2015;
+    tsConfig.options.module = ts.ModuleKind.ES2015;
+    tsConfig.options.moduleResolution = ts.ModuleResolutionKind.NodeJs;
+
+    // force correct declaration options
+    tsConfig.options.declaration = true;
+    tsConfig.options.declarationDir = undefined;
+
+    // force correct source map options
+    tsConfig.options.sourceMap = true;
+    tsConfig.options.inlineSources = true;
+    tsConfig.options.inlineSourceMap = false;
+    tsConfig.options.mapRoot = undefined;
+
+    tsConfig.options.allowSyntheticDefaultImports = true;
+    tsConfig.options.skipLibCheck = true;
+    tsConfig.options.emitDecoratorMetadata = true;
+    tsConfig.options.experimentalDecorators = true;
+    tsConfig.options.annotateForClosureCompiler = true;
+    tsConfig.options.skipTemplateCodegen = true;
+    tsConfig.options.strictMetadataEmit = true;
+
+    // this must be set to true or component selectors might be renamed
+    tsConfig.options.generateCodeForLibraries = true;
 
     switch (ngPkg.jsxConfig) {
       case 'preserve':

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -18,10 +18,15 @@
       "type": "string",
       "default": "dist"
     },
+    "tsconfig": {
+      "description": "The name of the typescript configuration file.",
+      "type": "string",
+      "default": ""
+    },
     "workingDirectory": {
       "description": "Internal working directory of ng-packagr where intermediate build files are stored (default: `.ng_pkg_build`).",
       "type": "string",
-      "default": ".ng_build"
+      "default": ".ng_pkg_build"
     },
     "lib": {
       "description": "Description of the library that is being built.",


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

fixes #256.
fixes #162.

To configure with a custom `tsconfig` file, put the path relative to your source path in the `tsconfig` field:

```json
{
  "$schema": "./node_modules/ng-packagr/package.schema.json",
  "ngPackage": {
    "tsconfig": "my-custom-tsconfig.json",
    "lib": {
      "entryFile": "public_api.ts"
    }
  }
}
```

The following fields can not be overridden:
- flatModuleId
- flatModuleOutFile
- basePath
- baseUrl
- outDir
- genDir
- target
- module
- moduleResolution
- declaration
- sourceMap
- inlineSources
- allowSyntheticDefaultImports
- skipLibCheck
- emitDecoratorMetadata
- experimentalDecorators
- annotateForClosureCompiler
- skipTemplateCodegen
- strictMetadataEmit

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
