### PR TITLE
feat: enable tslib `importHelpers` by default

### DIFF
--- a/integration/samples/core/specs/sourcemaps.ts
+++ b/integration/samples/core/specs/sourcemaps.ts
@@ -16,12 +16,12 @@ describe(`@sample/core`, () => {
 
     it(`should have 'sources' property`, () => {
       expect(sourceMap.sources).to.be.an('array').that.is.not.empty;
-      expect(sourceMap.sources).to.have.lengthOf(6);
+      expect(sourceMap.sources).to.have.lengthOf(7);
     });
 
     it(`should have 'sourcesContent' property`, () => {
       expect(sourceMap.sourcesContent).to.be.an('array').that.is.not.empty;
-      expect(sourceMap.sourcesContent).to.have.lengthOf(6);
+      expect(sourceMap.sourcesContent).to.have.lengthOf(7);
     });
 
     it(`should reference each 'sources' path with a common prefix`, () => {

--- a/src/lib/conf/tsconfig.ngc.json
+++ b/src/lib/conf/tsconfig.ngc.json
@@ -20,6 +20,7 @@
     "skipLibCheck": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "lib": [
       "dom",
       "es2015"


### PR DESCRIPTION
tslib helpers will not be emitted in the JavaScript output. Rollup will inline required helpers only once in a bundle file. Results in smaller bundle files.

## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Closes #337

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
