### PR TITLE
fix(): show proper path of failure on sass inline

### DIFF
--- a/src/lib/steps/assets.ts
+++ b/src/lib/steps/assets.ts
@@ -87,7 +87,7 @@ const processStylesheet =
 
       return Promise.resolve(result.css);
     } catch (err) {
-      return Promise.reject(new Error(`Cannot inline stylesheet ${path}`));
+      return Promise.reject(new Error(`Cannot inline stylesheet ${stylesheetFilePath}`));
     }
 
   }


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Description

when the sass inline fails it shows that it failed in `Object object` when it should tell you which file failed.. this is because its not getting the proper variable that contains the filePath

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
