### PR TITLE
feat: discover entry points from user configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,12 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "sample: package-js",
+      "program": "${workspaceRoot}/integration/samples/package-js/build.dev.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "sample: same-name",
       "program": "${workspaceRoot}/integration/samples/same-name/build.dev.js"
     },

--- a/README.md
+++ b/README.md
@@ -85,9 +85,25 @@ What about [ng-packagr alongside Nx Workspace](https://github.com/dherges/nx-pac
 
 #### Configuration Locations
 
-Configuration is picked up from the cli `-p` parameter, then from `package.json`, then from `ng-package.json` and lastly from `ng-package.js`.
+Configuration is picked up from the project file given by the `-p` CLI option.
+The `-p `option may refer to a `package.json` (with custom `ngPackage` property), an `ng-package.json`, or an `ng-package.js` file.
+When the `-p` option refers to a directory, the configuration is picked up from the first matching source;
+locations are tried in the above-mentioned order.
 
-To configure with a `ng-package.json` or `ng-package.js`, put the `package.json` of the library in the same folder next to the `ng-package.json` or `ng-package.js`.
+To configure with a `package.json`, put the configuration in the `ngPackage` custom property:
+
+```json
+{
+  "$schema": "./node_modules/ng-packagr/package.schema.json",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
+  }
+}
+```
+
+To configure with a `ng-package.json` or `ng-package.js`, keep the library's `package.json` in the same folder next to `ng-package.json` or `ng-package.js`.
 
 Example of `ng-package.json`:
 
@@ -108,19 +124,6 @@ module.exports = {
     entryFile: 'public_api.ts'
   }
 };
-```
-
-To configure with a `package.json`, put the configuration in the `ngPackage` custom property:
-
-```json
-{
-  "$schema": "./node_modules/ng-packagr/package.schema.json",
-  "ngPackage": {
-    "lib": {
-      "entryFile": "public_api.ts"
-    }
-  }
-}
 ```
 
 Note: referencing the `$schema` enables JSON editing support (auto-completion for configuration) in IDEs like [VSCode](https://github.com/Microsoft/vscode).

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ What about [ng-packagr alongside Nx Workspace](https://github.com/dherges/nx-pac
 
 #### Configuration Locations
 
-Configuration is picked up from the cli `-p` parameter, then from the default location for  `ng-package.json`, then from `package.json`.
+Configuration is picked up from the cli `-p` parameter, then from `package.json`, then from `ng-package.json` and lastly from `ng-package.js`.
 
-To configure with a `ng-package.json`, put the `package.json` of the library in the same folder next to the `ng-package.json`.
-Contents of `ng-package.json` are for example:
+To configure with a `ng-package.json` or `ng-package.js`, put the `package.json` of the library in the same folder next to the `ng-package.json` or `ng-package.js`.
+
+Example of `ng-package.json`:
 
 ```json
 {
@@ -97,6 +98,16 @@ Contents of `ng-package.json` are for example:
     "entryFile": "public_api.ts"
   }
 }
+```
+
+Example of `ng-package.js`:
+
+```js
+module.exports = {
+  lib: {
+    entryFile: 'public_api.ts'
+  }
+};
 ```
 
 To configure with a `package.json`, put the configuration in the `ngPackage` custom property:

--- a/integration/samples.sh
+++ b/integration/samples.sh
@@ -3,12 +3,17 @@ set -e
 
 for D in `find ./integration/samples/* -maxdepth 0 -type d`
 do
-    P=${D}/ng-package.json
-    if [ -f $P ]; then
-        echo "Building sample ${P}..."
-        node dist/cli/main.js -p ${P}
+    P_JS=${D}/ng-package.js
+    P_JSON=${D}/ng-package.json
+    P=${D}/package.json
+
+    if [ -f $P_JS ]; then
+        echo "Building sample ${P_JS}..."
+        node dist/cli/main.js -p ${P_JS}
+    elif [ -f $P_JSON ]; then
+        echo "Building sample ${P_JSON}..."
+        node dist/cli/main.js -p ${P_JSON}
     else
-        P=${D}/package.json
         echo "Building sample ${P}..."
         node dist/cli/main.js -p ${P}
     fi

--- a/integration/samples/package-js/README.md
+++ b/integration/samples/package-js/README.md
@@ -1,0 +1,4 @@
+Sample library: Configuration in ng-package.js
+======================================
+
+The configuration in this sample resides inside `ng-package.js`.

--- a/integration/samples/package-js/baz/baz.component.ts
+++ b/integration/samples/package-js/baz/baz.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'baz-component',
+  template: '<h1>hello world</h1>'
+})
+export class BazComponent {
+}

--- a/integration/samples/package-js/build.dev.js
+++ b/integration/samples/package-js/build.dev.js
@@ -1,0 +1,13 @@
+const path = require('path');
+process.env.DEBUG = true;
+
+// @see https://github.com/TypeStrong/ts-node#programmatic-usage
+require('ts-node').register({
+  project: path.join(__dirname, '..', '..', '..', 'tsconfig.packagr.json')
+});
+
+const ngPackagr = require('../../../src/lib/ng-packagr');
+
+ngPackagr.createNgPackage({
+  project: path.resolve(__dirname, 'ng-package.js')
+});

--- a/integration/samples/package-js/index.ts
+++ b/integration/samples/package-js/index.ts
@@ -1,0 +1,2 @@
+export * from './baz/baz.component';
+export * from './ui-lib.module';

--- a/integration/samples/package-js/ng-package.js
+++ b/integration/samples/package-js/ng-package.js
@@ -1,0 +1,5 @@
+module.exports = {
+  lib: {
+    entryFile: 'index.ts'
+  }
+};

--- a/integration/samples/package-js/package.json
+++ b/integration/samples/package-js/package.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../../src/package.schema.json",
+  "name": "@sample/package-js",
+  "description": "A sample library with configuration in ng-package.js",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  }
+}

--- a/integration/samples/package-js/secondary/baz/baz.component.ts
+++ b/integration/samples/package-js/secondary/baz/baz.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'baz-component',
+  template: '<h1>hello world</h1>'
+})
+export class BazComponent {
+}

--- a/integration/samples/package-js/secondary/index.ts
+++ b/integration/samples/package-js/secondary/index.ts
@@ -1,0 +1,2 @@
+export * from './baz/baz.component';
+export * from './ui-lib.module';

--- a/integration/samples/package-js/secondary/ng-package.js
+++ b/integration/samples/package-js/secondary/ng-package.js
@@ -1,0 +1,2 @@
+const config =  require('../ng-package');
+module.exports = config;

--- a/integration/samples/package-js/secondary/package.json
+++ b/integration/samples/package-js/secondary/package.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../../src/package.schema.json",
+  "name": "@sample/package-js-secondary"
+}

--- a/integration/samples/package-js/secondary/ui-lib.module.ts
+++ b/integration/samples/package-js/secondary/ui-lib.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { BazComponent } from './baz/baz.component';
+
+@NgModule({
+  declarations: [
+    BazComponent,
+  ],
+  exports: [
+    BazComponent,
+  ]
+})
+export class UiLibModule {}

--- a/integration/samples/package-js/specs/package.ts
+++ b/integration/samples/package-js/specs/package.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`@sample/package-js`, () => {
+
+  describe(`package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/package.json');
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+  });
+
+  describe(`secondary/package.json`, () => {
+    let PACKAGE;
+    before(() => {
+      PACKAGE = require('../dist/secondary/package.json');
+    });
+
+    it(`should exist`, () => {
+      expect(PACKAGE).to.be.ok;
+    });
+  });
+
+});

--- a/integration/samples/package-js/ui-lib.module.ts
+++ b/integration/samples/package-js/ui-lib.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { BazComponent } from './baz/baz.component';
+
+@NgModule({
+  declarations: [
+    BazComponent,
+  ],
+  exports: [
+    BazComponent,
+  ]
+})
+export class UiLibModule {}


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Discovery of primary and secondary entry points have been changed to the following;
 - `package.json`: with `ngPackage` property
 - `ng-package.json` (requires a `package.json` as sibling)
 - `ng-package.js` (default export, requires a `package.json` as sibling)

Closes: #190



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
