### PR TITLE
fix: set ngc emit callback for `tsickle`  processing

### DIFF
--- a/integration/samples/core/specs/sourcemaps.ts
+++ b/integration/samples/core/specs/sourcemaps.ts
@@ -14,14 +14,10 @@ describe(`@sample/core`, () => {
       expect(sourceMap).to.be.ok;
     });
 
-    it(`should have 'sources' property`, () => {
+    it(`should have 'sources' and 'sourcesContent' property`, () => {
       expect(sourceMap.sources).to.be.an('array').that.is.not.empty;
-      expect(sourceMap.sources).to.have.lengthOf(7);
-    });
-
-    it(`should have 'sourcesContent' property`, () => {
       expect(sourceMap.sourcesContent).to.be.an('array').that.is.not.empty;
-      expect(sourceMap.sourcesContent).to.have.lengthOf(7);
+      expect(sourceMap.sources).to.have.lengthOf(sourceMap.sourcesContent.length);
     });
 
     it(`should reference each 'sources' path with a common prefix`, () => {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "peerDependencies": {
     "@angular/compiler": "~5.0.0",
     "@angular/compiler-cli": "~5.0.0",
+    "tsickle": "^0.24.1",
     "typescript": "~2.4.2"
   },
   "devDependencies": {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 import * as program from 'commander';
 import * as path from 'path';

--- a/src/lib/entry-point-transforms.ts
+++ b/src/lib/entry-point-transforms.ts
@@ -51,7 +51,7 @@ export const transformSources =
 
     // 1. NGC
     log.info('Compiling with ngc');
-    const tsOutput = await ngc(entryPoint, artefacts.tsSources, artefacts.tsConfig);
+    const tsOutput = await ngc(entryPoint, artefacts);
     artefacts.tsSources.dispose();
 
     // await remapSourceMap(tsOutput.js);

--- a/src/lib/steps/ngc.ts
+++ b/src/lib/steps/ngc.ts
@@ -7,6 +7,10 @@ import * as ts from 'typescript';
 import { Artefacts } from '../domain/build-artefacts';
 import { NgEntryPoint } from '../domain/ng-package-format';
 import * as log from '../util/log';
+// XX: internal in ngc's `main()`, a tsickle emit callback is passed to the tsc compiler
+// ... blatanlty copy-paste the emit callback here. it's not a public api.
+// ... @link https://github.com/angular/angular/blob/24bf3e2a251634811096b939e61d63297934579e/packages/compiler-cli/src/main.ts#L36-L38
+import { createEmitCallback } from '../util/ngc-patches';
 import { componentTransformer } from '../util/ts-transformers';
 
 /** TypeScript configuration used internally (marker typer). */
@@ -44,6 +48,7 @@ export const prepareTsConfig =
     return tsConfig;
   }
 
+/** Transforms TypeScript AST */
 const transformSources =
   (tsConfig: TsConfig, transformers: ts.TransformerFactory<ts.SourceFile>[]): ts.TransformationResult<ts.SourceFile> => {
     const compilerHost: ng.CompilerHost = ng.createCompilerHost({
@@ -54,8 +59,6 @@ const transformSources =
       options: tsConfig.options,
       host: compilerHost
     });
-
-    // transform typescript AST prior to compilation
     const transformationResult: ts.TransformationResult<ts.SourceFile> = ts.transform(
       program.getTsProgram().getSourceFiles(),
       transformers,
@@ -65,19 +68,36 @@ const transformSources =
     return transformationResult;
   }
 
-const compilerHostFromTransformation =
-  ({transformation, options}: {transformation: ts.TransformationResult<ts.SourceFile>, options: ts.CompilerOptions}): ts.CompilerHost => {
-    const wrapped = ts.createCompilerHost(options);
+//const compilerHostFromTransformation =
+//  ({transformation, options}: {transformation: ts.TransformationResult<ts.SourceFile>, options: ts.CompilerOptions}): ts.CompilerHost => {
+
+const compilerHostFromArtefacts =
+  (artefacts: Artefacts) => {
+    const wrapped = ts.createCompilerHost(artefacts.tsConfig.options);
 
     return {
       ...wrapped,
       getSourceFile: (fileName, version) => {
-        const inTransformation = transformation.transformed.find((file) => file.fileName === fileName);
+        const inTransformation = artefacts.tsSources.transformed
+          .find((file) => file.fileName === fileName);
 
         if (inTransformation) {
           // FIX see https://github.com/Microsoft/TypeScript/issues/19950
           if (!inTransformation['ambientModuleNames']) {
             inTransformation['ambientModuleNames'] = inTransformation['original']['ambientModuleNames'];
+          }
+
+          // FIX synthesized source files cause ngc/tsc/tsickle to chock
+          if ((inTransformation.flags & 8) !== 0) {
+            const sourceText = artefacts.extras<SynthesizedSourceFile>(`ts:${inTransformation.fileName}`).writeSourceText();
+
+            return ts.createSourceFile(
+              inTransformation.fileName,
+              sourceText,
+              inTransformation.languageVersion,
+              true,
+              ts.ScriptKind.TS
+            );
           }
 
           return inTransformation;
@@ -111,13 +131,54 @@ export const collectTemplateAndStylesheetFiles =
     );
   }
 
+class SynthesizedSourceFile {
+
+  private replacemenets: { from: number, to: number, text: string}[] = [];
+
+  constructor(
+    private original: ts.SourceFile
+  ) {}
+
+  addReplacement(replacement: { from: number, to: number, text: string}) {
+    this.replacemenets.push(replacement);
+  }
+
+  public writeSourceText(): string {
+    const originalSource = this.original.getFullText();
+
+    let newSource = '';
+    let position = 0;
+    for (let replacement of this.replacemenets) {
+      newSource = newSource.concat(originalSource.substring(position, replacement.from))
+        .concat(replacement.text);
+      position = replacement.to;
+    }
+    newSource = newSource.concat(originalSource.substring(position));
+
+    return newSource;
+  }
+
+}
+
 /** Transforms templateUrl and styleUrls in `@Component({..})` decorators. */
 export const inlineTemplatesAndStyles =
   (tsConfig: TsConfig, artefacts: Artefacts): ts.TransformationResult<ts.SourceFile> => {
     // inline contents from artefacts set (generated in a previous step)
     const transformer = componentTransformer({
       templateProcessor: (a, b, templateFilePath) => artefacts.template(templateFilePath) || '',
-      stylesheetProcessor: (a, b, styleFilePath) => artefacts.stylesheet(styleFilePath) || ''
+      stylesheetProcessor: (a, b, styleFilePath) => artefacts.stylesheet(styleFilePath) || '',
+      sourceFileWriter: (sourceFile, node, synthesizedSourceText) => {
+        const key = `ts:${sourceFile.fileName}`;
+
+        const synthesizedSourceFile = artefacts.extras<SynthesizedSourceFile>(key) || new SynthesizedSourceFile(sourceFile);
+        synthesizedSourceFile.addReplacement({
+          from: node.getStart(),
+          to: node.getEnd(),
+          text: synthesizedSourceText
+        });
+
+        artefacts.extras(key, synthesizedSourceFile);
+      }
     });
 
     return transformSources(
@@ -132,16 +193,19 @@ export const inlineTemplatesAndStyles =
  * @param entryPoint Angular package data
  * @returns Promise<{}> Pathes of the flatModuleOutFile
  */
-export async function ngc(entryPoint: NgEntryPoint, sources: ts.TransformationResult<ts.SourceFile>, tsConfig: TsConfig) {
+export async function ngc(entryPoint: NgEntryPoint, artefacts: Artefacts) {
   log.debug(`ngc (v${ng.VERSION.full}): ${entryPoint.entryFile}`);
 
   // ng.CompilerHost
+  const tsConfig = artefacts.tsConfig;
   const ngCompilerHost = ng.createCompilerHost({
     options: tsConfig.options,
-    tsHost: compilerHostFromTransformation({
-      options: tsConfig.options,
-      transformation: sources
-    })
+    tsHost: compilerHostFromArtefacts(artefacts)
+
+    /*{
+      options: artefacts.tsConfig.options,
+      transformation: artefacts.tsSources
+    })*/
   });
 
   // ng.Program
@@ -156,6 +220,7 @@ export async function ngc(entryPoint: NgEntryPoint, sources: ts.TransformationRe
     rootNames: [ ...tsConfig.rootNames ],
     options: tsConfig.options,
     emitFlags: tsConfig.emitFlags,
+    emitCallback: createEmitCallback(tsConfig.options),
     host: ngCompilerHost,
     oldProgram: ngProgram
   });

--- a/src/lib/util/ngc-patches.ts
+++ b/src/lib/util/ngc-patches.ts
@@ -1,0 +1,59 @@
+/*
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+// @link https://github.com/angular/angular/blob/24bf3e2a251634811096b939e61d63297934579e/packages/compiler-cli/src/transformers/util.ts#L14
+const GENERATED_FILES = /(.*?)\.(ngfactory|shim\.ngstyle|ngstyle|ngsummary)\.(js|d\.ts|ts)$/;
+
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tsickle from 'tsickle';
+import * as api from '@angular/compiler-cli';
+
+// @link https://github.com/angular/angular/blob/24bf3e2a251634811096b939e61d63297934579e/packages/compiler-cli/src/main.ts#L41-L80
+export function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|undefined {
+  const transformDecorators = options.annotationsAs !== 'decorators';
+  const transformTypesToClosure = options.annotateForClosureCompiler;
+  if (!transformDecorators && !transformTypesToClosure) {
+    return undefined;
+  }
+  if (transformDecorators) {
+    // This is needed as a workaround for https://github.com/angular/tsickle/issues/635
+    // Otherwise tsickle might emit references to non imported values
+    // as TypeScript elided the import.
+    options.emitDecoratorMetadata = true;
+  }
+  const tsickleHost: tsickle.TsickleHost = {
+    shouldSkipTsickleProcessing: (fileName) =>
+                                     /\.d\.ts$/.test(fileName) || GENERATED_FILES.test(fileName),
+    pathToModuleName: (context, importPath) => '',
+    shouldIgnoreWarningsForPath: (filePath) => false,
+    fileNameToModuleId: (fileName) => fileName,
+    googmodule: false,
+    untyped: true,
+    convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
+  };
+
+  return ({
+           program,
+           targetSourceFile,
+           writeFile,
+           cancellationToken,
+           emitOnlyDtsFiles,
+           customTransformers = {},
+           host,
+           options
+         }) =>
+             tsickle.emitWithTsickle(
+                 program, tsickleHost, host, options, targetSourceFile, writeFile,
+                 cancellationToken, emitOnlyDtsFiles, {
+                   beforeTs: customTransformers.before,
+                   afterTs: customTransformers.after,
+                 });
+}


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

ng-packagr misses to run tsickle on the generated JavaScript output, even if `annotateForClosureCompiler: true` is set. Register the emit callback for `ngc` 


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
