### PR TITLE
test: reproduce `ts.NodeFlags.Synthesized` issues

### DIFF
--- a/integration/samples/custom/src/foo-bar/foo-bar.component.html
+++ b/integration/samples/custom/src/foo-bar/foo-bar.component.html
@@ -1,1 +1,1 @@
-<h1>Foo-Bar!</h1>
+<h1 #heading>Foo-Bar!</h1>

--- a/integration/samples/custom/src/foo-bar/foo-bar.component.ts
+++ b/integration/samples/custom/src/foo-bar/foo-bar.component.ts
@@ -1,8 +1,19 @@
-import { Component } from '@angular/core';
+import {Component, ContentChild, ElementRef, HostListener, Input, QueryList} from "@angular/core";
 
 @Component({
   selector: 'custom-foo-bar',
   templateUrl: './foo-bar.component.html',
   styleUrls: ['./foo-bar.component.styl']
 })
-export class FooBarComponent {}
+export class FooBarComponent {
+    @ContentChild('heading', { read: ElementRef })
+    buttons: ElementRef;
+
+    constructor(
+      private elementRef: ElementRef
+    ) {}
+
+    inlineButtons: any[] = [];
+    menuButtons: any[] = [];
+
+}


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Reproduces the issues faced with `ts.NodeFlags.Synthesized` in clarity's (and other's) build.

ngc/tsc failed for:
- visiting constructor parameters of a class with a synthesized decorator
- visiting members of a class with a synthesized decorator

See #369


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
