### PR TITLE
fix: relax on non-call-expression decorators in typescript parsing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,47 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "yarn samples:dev",
+      "name": "Mocha Tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "env": {
+        "TS_NODE_PROJECT": "src/tsconfig.specs.json"
+      },
+      "args": [
+        "--ui",
+        "tdd",
+        "--timeout",
+        "4000",
+        "--colors",
+        "--require",
+        "ts-node/register",
+        "${workspaceRoot}/src/**/*.spec.ts"
+      ],
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Integration Tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "env": {
+        "TS_NODE_PROJECT": "integration/tsconfig.specs.json"
+      },
+      "args": [
+        "--ui",
+        "tdd",
+        "--timeout",
+        "4000",
+        "--colors",
+        "--require",
+        "ts-node/register",
+        "${workspaceRoot}/integration/samples/*/specs/**.ts"
+      ],
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "samples (all)",
       "program": "${workspaceRoot}/integration/samples.dev.js"
     },
     {

--- a/integration/samples.dev.js
+++ b/integration/samples.dev.js
@@ -16,7 +16,7 @@ if (process.argv[2]) {
 
 // @see https://github.com/TypeStrong/ts-node#programmatic-usage
 require('ts-node').register({
-  project: path.join(__dirname, '..', 'tsconfig.packagr.json')
+  project: path.join(__dirname, '..', 'src', 'tsconfig.packagr.json')
 });
 
 const ngPackagr = require('../src/lib/ng-packagr');

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "integration:samples:dev": "./integration/samples.dev.js",
     "integration:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register integration/samples/*/specs/**/*.ts",
     "integration:consumer": "integration/consumer.sh",
+    "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register src/**/*.spec.ts",
     "test": "yarn build && yarn integration:samples && yarn integration:specs && yarn integration:consumer",
     "commitmsg": "commitlint -e",
     "gh-pages": "gh-pages -d docs/ghpages"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "private": true,
   "scripts": {
     "prebuild": "rimraf dist && yarn schema",
-    "build": "tsc -p tsconfig.packagr.json",
+    "build": "tsc -p src/tsconfig.packagr.json",
     "postbuild": "node scripts/postbuild.js",
     "schema": "json2ts --input src/ng-package.schema.json --output src/ng-package.schema.ts",
     "prerelease": "yarn build",

--- a/package.json
+++ b/package.json
@@ -95,11 +95,11 @@
   "scripts": {
     "prebuild": "rimraf dist && yarn schema",
     "build": "tsc -p src/tsconfig.packagr.json",
-    "postbuild": "node scripts/postbuild.js",
+    "postbuild": "./scripts/postbuild.js",
     "schema": "json2ts --input src/ng-package.schema.json --output src/ng-package.schema.ts",
     "prerelease": "yarn build",
     "release": "standard-version --message 'release: cut v%s'",
-    "postrelease": "node scripts/prepublish.js",
+    "postrelease": "./scripts/prepublish.js",
     "publish:ci": "yarn prerelease && yarn postrelease",
     "integration:samples": "integration/samples.sh",
     "integration:samples:dev": "./integration/samples.dev.js",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": ">=2.4.2 <2.6"
   },
   "devDependencies": {
+    "@angular-devkit/core": "^0.0.22",
     "@angular/cdk": "~5.0.0",
     "@angular/common": "~5.1.0",
     "@angular/compiler": "~5.1.0",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const copyfiles = require('copyfiles');
 
 const copy = (paths, opts) => {
@@ -13,10 +14,6 @@ const copy = (paths, opts) => {
     });
   });
 };
-
-// copyfiles 'cli/*' dist
-// copyfiles -f 'lib/ng-package.schema.json' dist
-// copyfiles 'lib/conf/**/*.json' dist",
 
 copy(['src/cli/*', 'dist'], {up: 1})
   .then(() => copy(['src/**.schema.json', 'dist'], {up: 1}))

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const cpx = require('cpx');
 const fs = require('fs');
 

--- a/src/lib/util/ts-transformers.spec.ts
+++ b/src/lib/util/ts-transformers.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import * as ts from 'typescript';
+import { isComponentDecorator } from './ts-transformers';
+
+describe(`ts-transformers`, () => {
+
+  describe(`isComponentDecorator`, () => {
+    const sourceFile = ts.createSourceFile('foo.ts',
+      `import {Component} from '@angular/core'; @Component({})class MyComponent{} @Directive()class Foo{}`,
+      ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    const decoratorNode = sourceFile.getChildAt(0).getChildAt(1)
+      .getChildAt(0).getChildAt(0);
+
+    it(`should return true for '@Component()'`, () => {
+      expect(isComponentDecorator(decoratorNode)).to.be.true;
+    });
+
+    it(`should return false for other decorator`, () => {
+      const otherDecorator = sourceFile.getChildAt(0).getChildAt(2)
+        .getChildAt(0).getChildAt(0);
+      expect(isComponentDecorator(otherDecorator)).to.be.false;
+    });
+
+    it(`should return false for non 'SyntaxKind.Decorator' nodes`, () => {
+      const nonDecoratorNode = sourceFile.getChildAt(0);
+      expect(isComponentDecorator(nonDecoratorNode)).to.be.false;
+    });
+  });
+});

--- a/src/lib/util/ts-transformers.spec.ts
+++ b/src/lib/util/ts-transformers.spec.ts
@@ -1,23 +1,29 @@
+import { tags } from '@angular-devkit/core';
 import { expect } from 'chai';
 import * as ts from 'typescript';
 import { isComponentDecorator } from './ts-transformers';
 
+const createSourceFile = (sourceText: string, sourceName: string = 'foo.ts') =>
+  ts.createSourceFile(sourceName, sourceText, ts.ScriptTarget.ES5, true, ts.ScriptKind.TS);
+
 describe(`ts-transformers`, () => {
 
   describe(`isComponentDecorator`, () => {
-    const sourceFile = ts.createSourceFile('foo.ts',
-      `import {Component} from '@angular/core'; @Component({})class MyComponent{} @Directive()class Foo{}`,
-      ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-    const decoratorNode = sourceFile.getChildAt(0).getChildAt(1)
-      .getChildAt(0).getChildAt(0);
+    const sourceFile = createSourceFile(tags.stripIndent`
+      import {Component} from '@angular/core';
+
+      @Component({})
+      @Other
+      class MyComponent {}
+    `);
 
     it(`should return true for '@Component()'`, () => {
+      const decoratorNode = sourceFile.getChildAt(0).getChildAt(1).getChildAt(0).getChildAt(0);
       expect(isComponentDecorator(decoratorNode)).to.be.true;
     });
 
     it(`should return false for other decorator`, () => {
-      const otherDecorator = sourceFile.getChildAt(0).getChildAt(2)
-        .getChildAt(0).getChildAt(0);
+      const otherDecorator = sourceFile.getChildAt(0).getChildAt(1).getChildAt(0).getChildAt(1);
       expect(isComponentDecorator(otherDecorator)).to.be.false;
     });
 

--- a/src/lib/util/ts-transformers.ts
+++ b/src/lib/util/ts-transformers.ts
@@ -2,16 +2,23 @@ import * as ts from 'typescript';
 import * as path from 'path';
 
 export const isComponentDecorator =
-  (node: ts.Node): node is ts.Decorator =>
-    ts.isDecorator(node) && node
-      .getChildren().find(ts.isCallExpression)
-      .getChildren().find(ts.isIdentifier)
-      .getText() === 'Component';
-      /* TODO: text comparison can break when
-       * `import { Component as foo } from '@angular/core'` or
-       * `import * as ng from '@angular/core'`
-       * @link https://github.com/angular/devkit/blob/master/packages/schematics/angular/utility/ast-utils.ts#L127-L128
-       */
+  (node: ts.Node): node is ts.Decorator => {
+    if (ts.isDecorator(node)) {
+      const callExpression = node.getChildren().find(ts.isCallExpression);
+      if (callExpression) {
+        const identifier = callExpression.getChildren().find(ts.isIdentifier);
+
+        return identifier && identifier.getText() === 'Component';
+        /* TODO: text comparison can break when
+        * `import { Component as foo } from '@angular/core'` or
+        * `import * as ng from '@angular/core'`
+        * @link https://github.com/angular/devkit/blob/master/packages/schematics/angular/utility/ast-utils.ts#L127-L128
+        */
+      }
+    }
+
+    return false;
+  }
 
 export const isPropertyAssignmentFor =
   (node: ts.Node, name: string): node is ts.PropertyAssignment =>

--- a/src/tsconfig.packagr.json
+++ b/src/tsconfig.packagr.json
@@ -18,5 +18,8 @@
   },
   "files": [
     "cli/main.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
   ]
 }

--- a/src/tsconfig.packagr.json
+++ b/src/tsconfig.packagr.json
@@ -8,7 +8,7 @@
     "inlineSources": true,
     "declaration": true,
     "lib": ["es2015", "dom"],
-    "outDir": "dist",
+    "outDir": "../dist",
     "experimentalDecorators": true,
     "noEmitOnError": true,
     "noImplicitAny": false,
@@ -17,6 +17,6 @@
     ]
   },
   "files": [
-    "src/cli/main.ts"
+    "cli/main.ts"
   ]
 }

--- a/src/tsconfig.specs.json
+++ b/src/tsconfig.specs.json
@@ -1,0 +1,27 @@
+{
+  "buildOnSave": false,
+  "compileOnSave": false,
+  "compilerOptions": {
+    "target": "es5",
+    "allowJs": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "es2015",
+      "es2016"
+    ],
+    "types": [
+      "chai",
+      "mocha",
+      "node",
+      "sinon"
+    ]
+  },
+  "include": [
+    "**/specs/*.ts"
+  ],
+  "exclude": [
+    ".ng_build",
+    ".ng_pkgr_build",
+    ".ng_pkg_build"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@angular-devkit/core@^0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-0.0.22.tgz#e90f46bf7ff47d260a767959267bc65ffee39ef1"
+  dependencies:
+    source-map "^0.5.6"
+
 "@angular/cdk@~5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-5.0.0.tgz#d7cb3294c9e3cc37d3d41c33e6beb044e84636c3"


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Allows non-call expression decorators in typescript parsing.

```ts
@Component({})
@Other
class Component {}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
