### PR TITLE
build: invoke `test:specs` when running the `test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "integration:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register integration/samples/*/specs/**/*.ts",
     "integration:consumer": "integration/consumer.sh",
     "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register src/**/*.spec.ts",
-    "test": "yarn build && yarn integration:samples && yarn integration:specs && yarn integration:consumer",
+    "test": "yarn build && yarn integration:samples && yarn integration:specs && yarn test:specs && yarn integration:consumer",
     "commitmsg": "commitlint -e",
     "gh-pages": "gh-pages -d docs/ghpages"
   },

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "integration:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register integration/samples/*/specs/**/*.ts",
     "integration:consumer": "integration/consumer.sh",
     "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register src/**/*.spec.ts",
-    "test": "yarn build && yarn integration:samples && yarn integration:specs && yarn test:specs && yarn integration:consumer",
+    "test": "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:consumer",
     "commitmsg": "commitlint -e",
     "gh-pages": "gh-pages -d docs/ghpages"
   },


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[X] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description
`test:specs` is not being run when invoking `test` in ci

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
