### PR TITLE
feat: support custom library paths

### DIFF
--- a/src/lib/domain/ng-package-format.ts
+++ b/src/lib/domain/ng-package-format.ts
@@ -110,6 +110,14 @@ export class NgEntryPoint {
     return this.$schema.$$get(key);
   }
 
+  public get src(): SourceFilePath {
+    return this.$get('src');
+  }
+
+  public get paths(): any {
+    return this.$get('paths');
+  }
+
   public get entryFile(): SourceFilePath {
     return this.$get('lib.entryFile');
   }

--- a/src/lib/steps/ngc.ts
+++ b/src/lib/steps/ngc.ts
@@ -29,6 +29,7 @@ export const prepareTsConfig: BuildStep =
     tsConfig.options.flatModuleOutFile = `${entryPoint.flatModuleFile}.js`;
     tsConfig.options.basePath = basePath;
     tsConfig.options.baseUrl = basePath;
+    tsConfig.options.paths = entryPoint.paths;
     tsConfig.options.outDir = artefacts.outDir;
     tsConfig.options.genDir = artefacts.outDir;
 
@@ -232,10 +233,16 @@ export async function ngc(entryPoint: NgEntryPoint, artefacts: Artefacts) {
 
     artefacts.tsSources.dispose();
 
+    // FIXME sometimes the lib is generated in a subfolder
+    // this searchs NgPackage.src as the subpath to search
+    const basePath = fs.existsSync(path.resolve(outDir, entryPoint.src, outFile)) ?
+      path.resolve(outDir, entryPoint.src, outFile) :
+      path.resolve(outDir, outFile);
+
     return Promise.resolve({
-      js: path.resolve(outDir, outFile),
-      metadata: path.resolve(outDir, outFile.replace(extName, '.metadata.json')),
-      typings: path.resolve(outDir, outFile.replace(extName, '.d.ts'))
+      js: basePath,
+      metadata: basePath.replace(extName, '.metadata.json'),
+      typings: basePath.replace(extName, '.d.ts')
     });
   } else {
     return Promise.reject(new Error(

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -23,6 +23,11 @@
       "type": "string",
       "default": ".ng_pkg_build"
     },
+    "paths": {
+      "description": "Path to sub-libraries.",
+      "type": "object",
+      "additionalProperties": true
+    },
     "lib": {
       "description": "Description of the library that is being built.",
       "type": "object",


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

I needed #379 so badly that I started some work supporting `compilerOptions.paths`, taking the values from a new property of `ngPackage.paths`. You have to take care of cyclic dependencies by yourself with a good design of course, but this currently allowed me to have my `@org/components` and two secondary entrypoints `@org/components/shared` and `@org/components/api`. Perhaps, this last one compiles in a subfolder `out/api`:
```
Bundling to FESM15
[debug] rollup (v0.52.1)
/components/.ng_pkg_build/org-components-api/out/api/org-components-api.js to
/components/.ng_pkg_build/org-components-api/stage/esm2015/org-components-api.js (es)
```
while the first one does it normally to `out`:
```
Bundling to FESM15
[debug] rollup (v0.52.1)
/components/.ng_pkg_build/org-components-shared/out/org-components-shared.js to
/components/.ng_pkg_build/org-components-shared/stage/esm2015/org-components-shared.js (es)
```
I checked that my secondary `api` doesn't include any external code, but got no luck, so I introduced a workaround to use `ngPackage.src` as a subfolder to search the compiled file, as I saw it wasn't used in the secondary tsConfig.

This is just a proposal to start supporting this feature, I'm not an expert on this topic but I needed this to much that I had to make it work. ATM it's working for me but I  have no time and not enough knowledge to build the tests or complete this, so this will be my 2 cents.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
