### PR TITLE
feat: remove `src` property from package schema

### DIFF
--- a/src/lib/domain/ng-package-format.ts
+++ b/src/lib/domain/ng-package-format.ts
@@ -47,9 +47,9 @@ export class NgPackage {
     public readonly secondaries: NgEntryPoint[] = []
   ) {}
 
-  /** Absolute path of the package's source directory. */
+  /** Absolute path of the package's source folder, derived from the user's (primary) package location. */
   public get src(): DirectoryPath {
-    return this.absolutePathFromPrimary('src');
+    return this.basePath;
   }
 
   /** Absolute path of the package's destination directory. */

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -8,13 +8,8 @@
     "$schema": {
       "type": "string"
     },
-    "src": {
-      "description": "The source folder of an Angular library. This is the folder where a `package.json` is located and defaults to cwd.",
-      "type": "string",
-      "default": "."
-    },
     "dest": {
-      "description": "The destination folder to output build artifacts and distributables of an Angular library (default: `dist`).",
+      "description": "Destination folder where distributable binaries of the Angular library are written (default: `dist`).",
       "type": "string",
       "default": "dist"
     },
@@ -24,11 +19,11 @@
       "default": ".ng_pkg_build"
     },
     "lib": {
-      "description": "Description of the library that is being built.",
+      "description": "Description of the library's entry point.",
       "type": "object",
       "properties": {
         "entryFile": {
-          "description": "Entry file to the public API of the library (default: `src/public_api.ts`).",
+          "description": "Entry file to the public API (default: `src/public_api.ts`).",
           "type": "string",
           "default": "src/public_api.ts"
         },
@@ -38,14 +33,14 @@
           "default": ""
         },
         "embedded": {
-          "description": "A array of external dependencies to be embedded in the final bundle.",
+          "description": "An array of external dependencies that will be embedded in the final bundle.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "umdModuleIds": {
-          "description": "A symbol map of external dependencies. The purpose of this map is to correctly bundle a flat module file (with `rollup`). By default, `rxjs`, `tslib` and `@angular/*` dependency symbols are supported.",
+          "description": "A map of external dependencies and their correspondent UMD module identifiers. Map keys are TypeScript / EcmaScript module identifiers. Map values are UMD module ids. The purpose of this map is to correctly bundle an UMD module file (with `rollup`). By default, `rxjs`, `tslib` and `@angular/*` dependency symbols are supported.",
           "type": "object",
           "additionalProperties": true
         },


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

No tests added. Tests were unchanged.

***BREAKING CHANGES:*** Setting `ngPackage.src` has no effect any more. The source directory (base path) is equivalent to the location of the (primary) `ng-package.json`, `package.json`, or `ng-package.js`.


## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
