### PR TITLE
Fix Jsx Integration Test

### DIFF
--- a/integration/consumers/tsc/src/jsx-consumer/jsx-consumer.component.ts
+++ b/integration/consumers/tsc/src/jsx-consumer/jsx-consumer.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'jsx-consumer',
   template: `
-<react-integration-test></react-integration-test>
-`
+    <react-integration-test></react-integration-test>
+  `
 })
 export class JsxConsumerComponent {}

--- a/integration/consumers/tsc/src/main.ts
+++ b/integration/consumers/tsc/src/main.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { FooComponent, BarComponent } from 'sample-custom';
 import { CoreConsumerModule } from './core-consumer/core-consumer.module';
 import { CustomConsulerModule } from './custom-consumer/custom-consumer.module';
-//import { JsxConsumerModule } from './jsx-consumer/jsx-consumer.module';
+import { JsxConsumerModule } from './jsx-consumer/jsx-consumer.module';
 import { MaterialConsumerModule } from './material-consumer/material-consumer.module';
 import { ModuleImportDirective } from './module-imports';
 
@@ -10,7 +10,7 @@ import { ModuleImportDirective } from './module-imports';
   imports: [
     CoreConsumerModule,
     CustomConsulerModule,
-    //JsxConsumerModule,
+    JsxConsumerModule,
     MaterialConsumerModule
   ],
   declarations: [

--- a/integration/consumers/tsc/tsconfig.json
+++ b/integration/consumers/tsc/tsconfig.json
@@ -15,17 +15,17 @@
     "moduleResolution": "node",
     "outDir": "dist",
     "rootDir": "src",
-    "baseUrl": "src",
+    "baseUrl": "./",
     "lib": [
       "es2015",
       "dom"
     ],
     "experimentalDecorators": true,
     "paths": {
-      "@sample/core": [ "../../../samples/core/dist" ],
-      "sample-custom": [ "../../../samples/custom/dist" ],
-      "@sample/jsx": [ "../../../samples/jsx/dist" ],
-      "@sample/material": [ "../../../samples/material/dist" ]
+      "@sample/core": [ "../../samples/core/dist" ],
+      "sample-custom": [ "../../samples/custom/dist" ],
+      "@sample/jsx": [ "../../samples/jsx/dist" ],
+      "@sample/material": [ "../../samples/material/dist" ]
     },
     "types": [
       "jasmine"


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

So I think that the reason these tests weren't passing before was due to the refactor making the `paths` in `tsconfig` out of date, they needed one else `../`. Then I ran into a class of issues that's described in these GitHub issues while running `yarn run integration:consumer:ngc`:

https://github.com/angular/vscode-ng-language-service/issues/183
https://github.com/angular/angular/issues/16382

I fixed that issue by changing `baseUrl` to be `./` and now when I run `yarn run integration:consumer:ngc` I don't get any errors.

Sorry it took me so long to get to this @dherges!

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
