### PR TITLE
fix: write type definition files (via triple-slash reference) to npm package

### DIFF
--- a/integration/samples/typings/specs/typings.ts
+++ b/integration/samples/typings/specs/typings.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+describe(`sample-typings`, () => {
+  describe(`validator.d.ts`, () => {
+    let VALIDATOR_DTS;
+    before(() => {
+      VALIDATOR_DTS = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'validator.d.ts'), 'utf-8');
+    });
+
+    it(`should triple-slash reference to 'src/chalk.d.ts'`, () => {
+      /// <reference path="src/chalk.d.ts" />
+      expect(VALIDATOR_DTS).to.contain('src/chalk.d.ts');
+      expect(VALIDATOR_DTS).to.satisfy(
+        (value: string) => value.startsWith(`/// <reference path="src/chalk.d.ts" />`),
+        'Expected validator.d.ts to contain a triple-slash reference');
+    });
+  });
+
+  describe(`src/chalk.d.ts`, () => {
+    let CHALK_DTS;
+    before(() => {
+      CHALK_DTS = fs.readFileSync(
+        path.resolve(__dirname, '..', 'dist', 'src', 'chalk.d.ts'), 'utf-8');
+    });
+
+    it(`should exist in 'dist' folder`, () => {
+      expect(CHALK_DTS).to.be.ok;
+    });
+  });
+});

--- a/integration/samples/typings/specs/typings.ts
+++ b/integration/samples/typings/specs/typings.ts
@@ -6,24 +6,23 @@ describe(`sample-typings`, () => {
   describe(`validator.d.ts`, () => {
     let VALIDATOR_DTS;
     before(() => {
-      VALIDATOR_DTS = fs.readFileSync(
-        path.resolve(__dirname, '..', 'dist', 'validator.d.ts'), 'utf-8');
+      VALIDATOR_DTS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'validator.d.ts'), 'utf-8');
     });
 
-    it(`should triple-slash reference to 'src/chalk.d.ts'`, () => {
-      /// <reference path="src/chalk.d.ts" />
-      expect(VALIDATOR_DTS).to.contain('src/chalk.d.ts');
+    it(`should triple-slash reference 'chalk.d.ts'`, () => {
+      /// <reference path="chalk.d.ts" />
+      expect(VALIDATOR_DTS).to.contain('chalk.d.ts');
       expect(VALIDATOR_DTS).to.satisfy(
-        (value: string) => value.startsWith(`/// <reference path="src/chalk.d.ts" />`),
-        'Expected validator.d.ts to contain a triple-slash reference');
+        (value: string) => value.startsWith(`/// <reference path="chalk.d.ts" />`),
+        'Expected validator.d.ts to contain a triple-slash reference'
+      );
     });
   });
 
   describe(`src/chalk.d.ts`, () => {
     let CHALK_DTS;
     before(() => {
-      CHALK_DTS = fs.readFileSync(
-        path.resolve(__dirname, '..', 'dist', 'src', 'chalk.d.ts'), 'utf-8');
+      CHALK_DTS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'chalk.d.ts'), 'utf-8');
     });
 
     it(`should exist in 'dist' folder`, () => {

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -33,12 +33,11 @@ import { DirectoryPath, SourceFilePath } from './shared';
  * The parent package of an entry point is reflected by `NgPackage`.
  */
 export class NgEntryPoint {
-
   constructor(
     public readonly packageJson: any,
     public readonly ngPackageJson: NgPackageConfig,
     private readonly $schema: SchemaClass<NgPackageConfig>,
-    private basePath: string,
+    private readonly basePath: string,
     private readonly secondaryData?: { [key: string]: any }
   ) {}
 
@@ -86,8 +85,9 @@ export class NgEntryPoint {
 
   public get sassIncludePaths(): string[] {
     const includePaths = this.$get('lib.sassIncludePaths') || [];
-    return includePaths.map(includePath =>
-      path.isAbsolute(includePath) ? includePath : path.resolve(this.basePath, includePath));
+    return includePaths.map(
+      includePath => (path.isAbsolute(includePath) ? includePath : path.resolve(this.basePath, includePath))
+    );
   }
 
   public get languageLevel(): string[] {
@@ -118,12 +118,14 @@ export class NgEntryPoint {
 
   private flattenModuleId(separator: string = '.') {
     if (this.moduleId.startsWith('@')) {
-      return this.moduleId.substring(1).split('/').join(separator);
+      return this.moduleId
+        .substring(1)
+        .split('/')
+        .join(separator);
     } else {
       return this.moduleId.split('/').join(separator);
     }
   }
-
 }
 
 export enum CssUrl {

--- a/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
+++ b/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
@@ -9,7 +9,11 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
 
   // Compile TypeScript sources
   const previousTransform = entryPoint.data.tsSources;
-  const compilationResult = await compileSourceFiles(entryPoint.data.tsSources.transformed, entryPoint.data.tsConfig);
+  const compilationResult = await compileSourceFiles(
+    entryPoint.data.tsSources.transformed,
+    entryPoint.data.tsConfig,
+    entryPoint.data.outDir
+  );
   previousTransform.dispose();
 
   // Store compilation result on the graph for further processing (`writeFlatBundles`)

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -17,6 +17,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
 
   // 5. COPY SOURCE FILES TO DESTINATION
   log.info('Copying staged files');
+  copyFiles(`${path.dirname(ngEntryPoint.entryFilePath)}/**/*.d.ts`, entryPoint.data.outDir);
   await copyJavaScriptBundles(entryPoint.data.stageDir, ngPackage.dest);
   await copyTypingsAndMetadata(entryPoint.data.outDir, ngEntryPoint.destinationPath);
 

--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -1,18 +1,29 @@
+import * as fs from 'fs-extra';
 import * as ng from '@angular/compiler-cli';
 import * as ts from 'typescript';
 import * as path from 'path';
 import { createCompilerHostForSynthesizedSourceFiles } from '../ts/synthesized-compiler-host';
+import { redirectWriteFileCompilerHost } from '../ts/redirect-write-file-compiler-host';
 import { TsConfig } from '../ts/tsconfig';
 import * as log from '../util/log';
 import { createEmitCallback } from './create-emit-callback';
 
-export async function compileSourceFiles(sourceFiles: ts.SourceFile[], tsConfig: TsConfig) {
+export async function compileSourceFiles(sourceFiles: ts.SourceFile[], tsConfig: TsConfig, outDir?: string) {
   log.debug(`ngc (v${ng.VERSION.full})`);
+
+  // ts.CompilerHost
+  let tsCompilerHost = createCompilerHostForSynthesizedSourceFiles(sourceFiles, tsConfig.options);
+  if (typeof outDir === 'string' && outDir.length) {
+    // Redirect file output
+    tsCompilerHost = redirectWriteFileCompilerHost(tsCompilerHost, tsConfig.options.basePath, outDir);
+  } else {
+    outDir = tsConfig.options.outDir;
+  }
 
   // ng.CompilerHost
   const ngCompilerHost = ng.createCompilerHost({
     options: tsConfig.options,
-    tsHost: createCompilerHostForSynthesizedSourceFiles(sourceFiles, tsConfig.options)
+    tsHost: tsCompilerHost
   });
 
   // ng.Program
@@ -32,16 +43,24 @@ export async function compileSourceFiles(sourceFiles: ts.SourceFile[], tsConfig:
     oldProgram: ngProgram
   });
 
+  const flatModuleFile = tsConfig.options.flatModuleOutFile;
+  const flatModuleFileExtension = path.extname(flatModuleFile);
+
+  // XX(hack): redirect the `*.metadata.json` to the correct outDir
+  // @link https://github.com/angular/angular/pull/21787
+  const metadataBundleFile = flatModuleFile.replace(flatModuleFileExtension, '.metadata.json');
+  const metadataSrc = path.resolve(tsConfig.options.outDir, metadataBundleFile);
+  const metadataDest = path.resolve(outDir, metadataBundleFile);
+  if (metadataDest !== metadataSrc && fs.existsSync(metadataSrc)) {
+    await fs.move(metadataSrc, metadataDest);
+  }
+
   const exitCode = ng.exitCodeFromResult(result.diagnostics);
   if (exitCode === 0) {
-    const outDir = tsConfig.options.outDir;
-    const outFile = tsConfig.options.flatModuleOutFile;
-    const extName = path.extname(outFile);
-
     return Promise.resolve({
-      js: path.resolve(outDir, outFile),
-      metadata: path.resolve(outDir, outFile.replace(extName, '.metadata.json')),
-      typings: path.resolve(outDir, outFile.replace(extName, '.d.ts'))
+      js: path.resolve(outDir, flatModuleFile),
+      metadata: metadataDest,
+      typings: path.resolve(outDir, flatModuleFile.replace(flatModuleFileExtension, '.d.ts'))
     });
   } else {
     return Promise.reject(new Error(ng.formatDiagnostics(result.diagnostics)));

--- a/src/lib/ts/redirect-write-file-compiler-host.ts
+++ b/src/lib/ts/redirect-write-file-compiler-host.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs-extra';
+import * as ts from 'typescript';
+import * as path from 'path';
+
+/**
+ * Returns a TypeScript compiler host that redirects `writeFile` output to the given `outDir`.
+ *
+ * @param compilerHost Original compiler host
+ * @param baseDir Project base directory
+ * @param outDir Target directory
+ */
+export function redirectWriteFileCompilerHost(
+  compilerHost: ts.CompilerHost,
+  baseDir: string,
+  outDir: string
+): ts.CompilerHost {
+  return {
+    ...compilerHost,
+    writeFile: (
+      fileName: string,
+      data: string,
+      writeByteOrderMark: boolean,
+      onError?: (message: string) => void,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>
+    ) => {
+      const projectRelativePath = path.relative(baseDir, fileName);
+      const filePath = path.resolve(outDir, projectRelativePath);
+      fs.outputFileSync(filePath, data);
+    }
+  };
+}

--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -38,7 +38,7 @@ export const initializeTsConfig = (defaultTsConfig: TsConfig, entryPoint: NgEntr
   tsConfig.options.basePath = basePath;
   tsConfig.options.baseUrl = basePath;
   tsConfig.options.rootDir = basePath;
-  tsConfig.options.outDir = outDir;
+  tsConfig.options.outDir = basePath;
   tsConfig.options.genDir = outDir;
 
   if (entryPoint.languageLevel) {


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Used to work in 2.0.0-rc.4

Broke in rc5 and later


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
