### PR TITLE
fix: remove moduleId from rollup bundle options

### DIFF
--- a/src/lib/steps/rollup.spec.ts
+++ b/src/lib/steps/rollup.spec.ts
@@ -3,7 +3,7 @@ import { externalModuleIdStrategy, umdModuleIdStrategy } from './rollup';
 
 describe('rollup', () => {
 
-  describe(externalModuleIdStrategy.name, () => {
+  describe(`externalModuleIdStrategy`, () => {
     it(`should return 'false' paths starting with '.'`, () => {
       expect(externalModuleIdStrategy('./foo/bar')).to.be.false;
     });
@@ -34,7 +34,7 @@ describe('rollup', () => {
 
   });
 
-  describe(umdModuleIdStrategy.name, () => {
+  describe(`umdModuleIdStrategy`, () => {
     it(`should map 'rxjs/add/observable/bindCallback' to 'Rx.Observable'`, () => {
       expect(umdModuleIdStrategy('rxjs/add/observable/bindCallback')).to.equal('Rx.Observable');
     });

--- a/src/lib/steps/rollup.ts
+++ b/src/lib/steps/rollup.ts
@@ -102,8 +102,6 @@ export async function rollup(opts: RollupOptions): Promise<void> {
 
   // Output the bundle to disk
   await bundle.write({
-    // Keep the moduleId empty because we don't want to force developers to a specific moduleId.
-    moduleId: '',
     name: `${opts.moduleName}`,
     file: opts.dest,
     format: opts.format,


### PR DESCRIPTION
Required change for rollup 0.53

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Blocks #438

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
