### PR TITLE
test: depend on `@sample/secondary` in Angular CLI app

### DIFF
--- a/integration/consumers.sh
+++ b/integration/consumers.sh
@@ -5,23 +5,21 @@ parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$parent_path"
 echo "Running consumer builds in $parent_path"
 
-# Prepare 'sample-custom'
-pushd samples/custom/dist
-yarn unlink || true
-yarn link
-popd
-
-# Prepare '@sample/material'
-pushd samples/material/dist
-yarn unlink || true
-yarn link
-popd
+# Prepare samples
+array=( 'custom' 'material' 'secondary' )
+for sample in "${array[@]}"; do
+    pushd "samples/${sample}/dist"
+    yarn unlink || true
+    yarn link
+    popd
+done
 
 # Build ng cli app
 pushd consumers/ng-cli
 yarn install
 yarn link sample-custom
 yarn link @sample/material
+yarn link @sample/secondary
 yarn build:dev --output-path dist/dev
 yarn build:prod:jit --output-path dist/jit
 yarn build:prod:aot --output-path dist/aot

--- a/integration/consumers/ng-cli/package.json
+++ b/integration/consumers/ng-cli/package.json
@@ -15,6 +15,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/cdk": "^5.0.2",
     "@angular/common": "~5.1.0",
     "@angular/compiler": "~5.1.0",
     "@angular/core": "~5.1.0",

--- a/integration/consumers/ng-cli/src/app/app.module.ts
+++ b/integration/consumers/ng-cli/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { CustomModule } from 'sample-custom';
 import { UiLibModule } from '@sample/material';
 
 import { AppComponent } from './app.component';
+import { CdkModule } from './cdk/cdk.module';
 
 @NgModule({
   declarations: [
@@ -17,8 +18,12 @@ import { AppComponent } from './app.component';
     FormsModule,
     HttpModule,
 
+    // samples
     CustomModule,
-    UiLibModule
+    UiLibModule,
+
+    // app
+    CdkModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/integration/consumers/ng-cli/src/app/cdk/cdk.module.ts
+++ b/integration/consumers/ng-cli/src/app/cdk/cdk.module.ts
@@ -1,0 +1,35 @@
+import { Component, NgModule, Version, InjectionToken } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VERSION } from '@angular/cdk';
+import { ObserversModule, CdkObserveContent } from '@angular/cdk/observers';
+import { CdkTableModule } from '@angular/cdk/table';
+
+const CDK_VERSION_TOKEN = new InjectionToken<Version>('VERSION_TOKEN');
+
+@Component({
+  selector: 'app-some-cdk-component',
+  template: `<div cdkObserveContent></div><cdk-table></cdk-table>`
+})
+export class SomeCdkComponent {}
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ObserversModule,
+    CdkTableModule
+  ],
+  declarations: [
+    SomeCdkComponent
+  ],
+  exports: [
+    ObserversModule,
+    SomeCdkComponent
+  ],
+  providers: [
+    {
+      provide: CDK_VERSION_TOKEN,
+      useValue: VERSION
+    }
+  ]
+})
+export class CdkModule {}

--- a/integration/consumers/ng-cli/src/app/secondary/secondary.module.ts
+++ b/integration/consumers/ng-cli/src/app/secondary/secondary.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { UiLibModule } from '@sample/secondary';
+// XX: why not working?!
+// import { UiLibModule as SubModule } from '@sample/secondary/sub-module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    UiLibModule,
+//    SubModule
+  ],
+  declarations: []
+})
+export class SecondaryModule { }

--- a/integration/consumers/ng-cli/yarn.lock
+++ b/integration/consumers/ng-cli/yarn.lock
@@ -37,6 +37,12 @@
     minimist "^1.2.0"
     rxjs "^5.5.2"
 
+"@angular/cdk@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-5.0.2.tgz#9d2505e5736a14a6b59d226280a7600559e6d707"
+  dependencies:
+    tslib "^1.7.1"
+
 "@angular/cli@~1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-1.6.0.tgz#eba521f6a8e4c2db628300baddbc4da13ca96998"

--- a/integration/samples/secondary/package.json
+++ b/integration/samples/secondary/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../src/package.schema.json",
-  "name": "@sample/secondary-lib",
+  "name": "@sample/secondary",
   "description": "A sample library with configuration in package.json",
   "version": "1.0.0-pre.0",
   "private": true,

--- a/integration/samples/secondary/specs/bundle.ts
+++ b/integration/samples/secondary/specs/bundle.ts
@@ -4,35 +4,35 @@ import * as path from 'path';
 
 describe(`@sample/secondary`, () => {
 
-  describe(`bundle: sample-secondary-lib.umd.js`, () => {
+  describe(`bundle: sample-secondary.umd.js`, () => {
     let BUNDLE;
     before(() => {
       BUNDLE = fs.readFileSync(
-        path.resolve(__dirname, '..', 'dist', 'bundles', 'sample-secondary-lib.umd.js'), 'utf-8');
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'sample-secondary.umd.js'), 'utf-8');
     });
 
     it(`should exist`, () => {
       expect(BUNDLE).to.be.ok;
     });
 
-    it(`should export the root module with module name 'sample.secondary-lib'`, () => {
-      expect(BUNDLE).to.contain(`global.sample['secondary-lib'] = {}`);
+    it(`should export the root module with module name 'sample.secondary'`, () => {
+      expect(BUNDLE).to.contain(`global.sample.secondary = {}`);
     });
   });
 
-  describe(`bundle: sample-secondary-lib-sub-module.umd.js`, () => {
+  describe(`bundle: sample-secondary-sub-module.umd.js`, () => {
     let BUNDLE;
     before(() => {
       BUNDLE = fs.readFileSync(
-        path.resolve(__dirname, '..', 'dist', 'bundles', 'sample-secondary-lib-sub-module.umd.js'), 'utf-8');
+        path.resolve(__dirname, '..', 'dist', 'bundles', 'sample-secondary-sub-module.umd.js'), 'utf-8');
     });
 
     it(`should exist`, () => {
       expect(BUNDLE).to.be.ok;
     });
 
-    it(`should export the secondary module with module name 'sample.secondary-lib.sub-module'`, () => {
-      expect(BUNDLE).to.contain(`global.sample['secondary-lib']['sub-module'] = {}`);
+    it(`should export the secondary module with module name 'sample.secondary.sub-module'`, () => {
+      expect(BUNDLE).to.contain(`global.sample.secondary['sub-module'] = {}`);
     });
   });
 

--- a/integration/samples/secondary/specs/es2015-api.ts
+++ b/integration/samples/secondary/specs/es2015-api.ts
@@ -2,12 +2,12 @@ import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 
-describe(`@sample/secondary-lib`, () => {
+describe(`@sample/secondary`, () => {
 
-  describe(`es2015: sample-secondary-lib.js`, () => {
+  describe(`es2015: sample-secondary.js`, () => {
     let API;
     before(() => {
-      API = require('../dist/esm2015/sample-secondary-lib.js');
+      API = require('../dist/esm2015/sample-secondary.js');
     });
 
     it(`should exist`, () => {
@@ -21,12 +21,12 @@ describe(`@sample/secondary-lib`, () => {
   });
 });
 
-describe(`@sample/secondary-lib/sub-module`, () => {
+describe(`@sample/secondary/sub-module`, () => {
 
-  describe(`es2015: sample-secondary-lib-sub-module.js`, () => {
+  describe(`es2015: sample-secondary-sub-module.js`, () => {
     let SECONDARY;
     before(() => {
-      SECONDARY = require('../dist/esm2015/sample-secondary-lib-sub-module.js');
+      SECONDARY = require('../dist/esm2015/sample-secondary-sub-module.js');
     });
 
     it(`should exist`, () => {

--- a/integration/samples/secondary/specs/es5-api.ts
+++ b/integration/samples/secondary/specs/es5-api.ts
@@ -2,12 +2,12 @@ import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 
-describe(`@sample/secondary-lib`, () => {
+describe(`@sample/secondary`, () => {
 
-  describe(`es5: sample-secondary-lib.js`, () => {
+  describe(`es5: sample-secondary.js`, () => {
     let API;
     before(() => {
-      API = require('../dist/esm5/sample-secondary-lib.js');
+      API = require('../dist/esm5/sample-secondary.js');
     });
 
     it(`should exist`, () => {
@@ -21,12 +21,12 @@ describe(`@sample/secondary-lib`, () => {
   });
 });
 
-describe(`@sample/secondary-lib/sub-module`, () => {
+describe(`@sample/secondary/sub-module`, () => {
 
-  describe(`es5: sample-secondary-lib-sub-module.js`, () => {
+  describe(`es5: sample-secondary-sub-module.js`, () => {
     let SECONDARY;
     before(() => {
-      SECONDARY = require('../dist/esm5/sample-secondary-lib-sub-module.js');
+      SECONDARY = require('../dist/esm5/sample-secondary-sub-module.js');
     });
 
     it(`should exist`, () => {

--- a/integration/samples/secondary/specs/metadata.ts
+++ b/integration/samples/secondary/specs/metadata.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 
 describe(`@sample/secondary`, () => {
 
-  describe(`sample-secondary-lib.metadata.json`, () => {
+  describe(`sample-secondary.metadata.json`, () => {
     let METADATA;
     before(() => {
-      METADATA = require('../dist/sample-secondary-lib.metadata.json');
+      METADATA = require('../dist/sample-secondary.metadata.json');
     });
 
     it(`should exist`, () => {
@@ -16,15 +16,15 @@ describe(`@sample/secondary`, () => {
       expect(METADATA['__symbolic']).to.equal('module');
     });
 
-    it(`should "importAs": "@sample/secondary-lib"`, () => {
-      expect(METADATA['importAs']).to.equal('@sample/secondary-lib');
+    it(`should "importAs": "@sample/secondary"`, () => {
+      expect(METADATA['importAs']).to.equal('@sample/secondary');
     });
   });
 
-  describe(`sample-secondary-lib-sub-module.metadata.json`, () => {
+  describe(`sample-secondary-sub-module.metadata.json`, () => {
     let METADATA;
     before(() => {
-      METADATA = require('../dist/sub-module/sample-secondary-lib-sub-module.metadata.json');
+      METADATA = require('../dist/sub-module/sample-secondary-sub-module.metadata.json');
     });
 
     it(`should exist`, () => {
@@ -35,8 +35,8 @@ describe(`@sample/secondary`, () => {
       expect(METADATA['__symbolic']).to.equal('module');
     });
 
-    it(`should "importAs": "@sample/secondary-lib/sub-module"`, () => {
-      expect(METADATA['importAs']).to.equal('@sample/secondary-lib/sub-module');
+    it(`should "importAs": "@sample/secondary/sub-module"`, () => {
+      expect(METADATA['importAs']).to.equal('@sample/secondary/sub-module');
     });
 
   });

--- a/integration/samples/secondary/specs/package.ts
+++ b/integration/samples/secondary/specs/package.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 
 describe(`@sample/secondary`, () => {
 
-  describe(`secondary-lib/package.json`, () => {
+  describe(`secondary/package.json`, () => {
     let PACKAGE;
     before(() => {
       PACKAGE = require('../dist/package.json');
@@ -18,24 +18,24 @@ describe(`@sample/secondary`, () => {
       expect(PACKAGE.ngPackage).to.be.undefined;
     });
 
-    it(`should be named '@sample/secondary-lib'`, () => {
-      expect(PACKAGE['name']).to.equal('@sample/secondary-lib');
+    it(`should be named '@sample/secondary'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/secondary');
     });
 
     it(`should reference "main" bundle (UMD)`, () => {
-      expect(PACKAGE['main']).to.equal('bundles/sample-secondary-lib.umd.js');
+      expect(PACKAGE['main']).to.equal('bundles/sample-secondary.umd.js');
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2015)`, () => {
-      expect(PACKAGE['module']).to.equal('esm5/sample-secondary-lib.js');
+      expect(PACKAGE['module']).to.equal('esm5/sample-secondary.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('esm2015/sample-secondary-lib.js');
+      expect(PACKAGE['es2015']).to.equal('esm2015/sample-secondary.js');
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('sample-secondary-lib.d.ts');
+      expect(PACKAGE['typings']).to.equal('sample-secondary.d.ts');
     });
   });
 
@@ -53,24 +53,24 @@ describe(`@sample/secondary`, () => {
       expect(PACKAGE.ngPackage).to.be.undefined;
     });
 
-    it(`should be named '@sample/secondary-lib/sub-module'`, () => {
-      expect(PACKAGE['name']).to.equal('@sample/secondary-lib/sub-module');
+    it(`should be named '@sample/secondary/sub-module'`, () => {
+      expect(PACKAGE['name']).to.equal('@sample/secondary/sub-module');
     });
 
     it(`should reference "main" bundle (UMD)`, () => {
-      expect(PACKAGE['main']).to.equal('../bundles/sample-secondary-lib-sub-module.umd.js');
+      expect(PACKAGE['main']).to.equal('../bundles/sample-secondary-sub-module.umd.js');
     });
 
     it(`should reference "module" bundle (FESM5, also FESM2015)`, () => {
-      expect(PACKAGE['module']).to.equal('../esm5/sample-secondary-lib-sub-module.js');
+      expect(PACKAGE['module']).to.equal('../esm5/sample-secondary-sub-module.js');
     });
 
     it(`should reference "es2015" bundle (FESM2015)`, () => {
-      expect(PACKAGE['es2015']).to.equal('../esm2015/sample-secondary-lib-sub-module.js');
+      expect(PACKAGE['es2015']).to.equal('../esm2015/sample-secondary-sub-module.js');
     });
 
     it(`should reference "typings" files`, () => {
-      expect(PACKAGE['typings']).to.equal('sample-secondary-lib-sub-module.d.ts');
+      expect(PACKAGE['typings']).to.equal('sample-secondary-sub-module.d.ts');
     });
   });
 

--- a/integration/samples/secondary/specs/umd.ts
+++ b/integration/samples/secondary/specs/umd.ts
@@ -3,10 +3,10 @@ import * as path from 'path';
 
 describe(`@sample/secondary`, () => {
 
-  describe(`sample-secondary-lib.umd.js`, () => {
+  describe(`sample-secondary.umd.js`, () => {
     let GENERATED;
     before(done => {
-      GENERATED = require('../dist/bundles/sample-secondary-lib.umd.js');
+      GENERATED = require('../dist/bundles/sample-secondary.umd.js');
       done();
     });
 
@@ -19,10 +19,10 @@ describe(`@sample/secondary`, () => {
     });
   });
 
-  describe(`sample-secondary-lib.umd.min.js`, () => {
+  describe(`sample-secondary.umd.min.js`, () => {
     let GENERATED;
     before(done => {
-      GENERATED = require('../dist/bundles/sample-secondary-lib.umd.min.js');
+      GENERATED = require('../dist/bundles/sample-secondary.umd.min.js');
       done();
     });
 
@@ -35,10 +35,10 @@ describe(`@sample/secondary`, () => {
     });
   });
 
-  describe(`sample-secondary-lib-sub-module.umd.js`, () => {
+  describe(`sample-secondary-sub-module.umd.js`, () => {
     let GENERATED;
     before(done => {
-      GENERATED = require('../dist/bundles/sample-secondary-lib-sub-module.umd.js');
+      GENERATED = require('../dist/bundles/sample-secondary-sub-module.umd.js');
       done();
     });
 
@@ -51,10 +51,10 @@ describe(`@sample/secondary`, () => {
     });
   });
 
-  describe(`sample-secondary-lib-sub-module.umd.min.js`, () => {
+  describe(`sample-secondary-sub-module.umd.min.js`, () => {
     let GENERATED;
     before(done => {
-      GENERATED = require('../dist/bundles/sample-secondary-lib-sub-module.umd.min.js');
+      GENERATED = require('../dist/bundles/sample-secondary-sub-module.umd.min.js');
       done();
     });
 


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Added integration test. Angular CLI app depends on `@sample/secondary` and `@sample/secondary/sub-module`. Verifies that secondary entry points are resolved in consumer app.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
