### PR TITLE
fix: supports extracting styles from multiple styleUrls

### DIFF
--- a/src/lib/util/ts-transformers.ts
+++ b/src/lib/util/ts-transformers.ts
@@ -79,6 +79,7 @@ export const componentTransformer: ComponentTransformer =
             .filter((node) => node.kind === ts.SyntaxKind.SyntaxList)
             .map((node) => node.getChildren().map(n => n.getText()))
             .reduce((prev, current) => prev.concat(...current), [])
+            .filter(text => text !== ',')
             .map((url) => url.substring(1, url.length - 1));
 
           const stylesheets = styleUrls.map((url: string) => {


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

This change will allow parsing and extracting styles from components that list multiple styleUrls (or that have a trailing comma on a single item)

For some reason the text returned by `node.getChildren().map(n => n.getText())` was including the comma delimiter for the array entries.

Addresses issues:
- #407 
- #424 


## Does this PR introduce a breaking change?

No, I don't presume any adverse side effects from this, since it's hard to foresee a future where commas aren't used to separate array entries.

