### PR TITLE
feat: stabilize command API, step towards customizing through DI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,27 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch current file w/ mocha",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "env": {
+        "TS_NODE_PROJECT": "src/tsconfig.specs.json"
+      },
+      "args": [
+        "--ui",
+        "tdd",
+        "--timeout",
+        "4000",
+        "--colors",
+        "--require",
+        "ts-node/register",
+        "${relativeFile}"
+      ],
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Mocha Tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "env": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cpx": "^1.5.0",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
+    "injection-js": "^2.2.1",
     "less": "^2.7.2",
     "node-sass": "^4.5.3",
     "node-sass-tilde-importer": "^1.0.0",
@@ -43,6 +44,7 @@
     "rollup": "^0.53.0",
     "rollup-plugin-commonjs": "^8.2.1",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rxjs": "^5.5.0",
     "sorcery": "^0.10.0",
     "stylus": "^0.54.5",
     "uglify-js": "^3.0.7"
@@ -87,7 +89,6 @@
     "mocha": "^4.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "rxjs": "^5.4.0",
     "sinon": "^4.0.0",
     "standard-version": "^4.0.0",
     "ts-node": "^4.0.0",

--- a/src/lib/commands/build.command.ts
+++ b/src/lib/commands/build.command.ts
@@ -1,5 +1,5 @@
 import { Command } from './command';
-import { buildNgPackage } from '../steps/build-ng-package';
+import { ngPackagr, provideProject } from '../ng-v5/packagr';
 
 /** CLI arguments passed to `ng-packagr` executable and `build()` command. */
 export interface CliArguments {
@@ -8,5 +8,10 @@ export interface CliArguments {
   project: string
 }
 
+/** @stable */
 export const build: Command<CliArguments, void> =
-  (opts) => buildNgPackage(opts);
+  (opts) => ngPackagr()
+    .withProviders([
+      provideProject(opts.project)
+    ])
+    .build();

--- a/src/lib/commands/command.ts
+++ b/src/lib/commands/command.ts
@@ -1,9 +1,13 @@
-/** Common call signature for a command */
+/**
+ * Common call signature for a command
+ *
+ * @stable
+ */
 export interface Command<Arguments, Result> {
   (args?: Arguments): Result | Promise<Result>
 }
 
-
+/** @stable */
 export function execute<A, R>(command: Command<A, R>, args?: A): Promise<R> {
 
   const result = args ? command(args) : command();

--- a/src/lib/commands/version.command.ts
+++ b/src/lib/commands/version.command.ts
@@ -23,6 +23,7 @@ function tryReadVersion(paths: string[] = []) {
   }
 }
 
+/** @stable */
 export const version: Command<undefined, void> =
   () => {
     tryReadVersion(['../../package.json', '../../../package.json']);

--- a/src/lib/ng-v5/packagr.spec.ts
+++ b/src/lib/ng-v5/packagr.spec.ts
@@ -18,6 +18,6 @@ describe(`provideProject()`, () => {
   it(`should return the ValueProvider`, () => {
     const provider = provideProject('foo');
     expect(provider.provide).to.equal(PROJECT_TOKEN);
-    expect(provider.useValue).to.be.ok;
+    expect(provider.useValue).to.equal('foo');
   });
 });

--- a/src/lib/ng-v5/packagr.spec.ts
+++ b/src/lib/ng-v5/packagr.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { provideProject, PROJECT_TOKEN, ngPackagr, NgPackagr } from './packagr';
+
+describe(`ngPackagr()`, () => {
+
+  it(`should return a NgPackagr instance`, () => {
+    const foo = ngPackagr();
+    expect(foo).to.be.an.instanceOf(NgPackagr);
+  });
+
+  xit(`should return something with pre-configured defaults`, () => {
+    // TODO
+  });
+});
+
+describe(`provideProject()`, () => {
+
+  it(`should return the ValueProvider`, () => {
+    const provider = provideProject('foo');
+    expect(provider.provide).to.equal(PROJECT_TOKEN);
+    expect(provider.useValue).to.be.ok;
+  });
+});

--- a/src/lib/ng-v5/packagr.ts
+++ b/src/lib/ng-v5/packagr.ts
@@ -1,0 +1,37 @@
+import { InjectionToken, Provider, ReflectiveInjector, ValueProvider } from 'injection-js';
+import { buildNgPackage } from '../steps/build-ng-package';
+
+export class NgPackagr {
+
+  constructor(
+    private providers: Provider[]
+  ) {}
+
+  public withProviders(providers: Provider[]): NgPackagr {
+    this.providers = [
+      ...this.providers,
+      ...providers
+    ];
+
+    return this;
+  }
+
+  public build(): Promise<void> {
+    const injector = ReflectiveInjector.resolveAndCreate(this.providers);
+    const fooToken = injector.get(PROJECT_TOKEN);
+
+    return buildNgPackage({ project: fooToken });
+  }
+
+}
+
+export const ngPackagr = (): NgPackagr => new NgPackagr([
+  // TODO: default providers come here
+]);
+
+export const PROJECT_TOKEN = new InjectionToken<string>('ng.v5.project');
+
+export const provideProject = (project: string): ValueProvider => ({
+  provide: PROJECT_TOKEN,
+  useValue: project
+});

--- a/src/lib/ng-v5/packagr.ts
+++ b/src/lib/ng-v5/packagr.ts
@@ -18,9 +18,9 @@ export class NgPackagr {
 
   public build(): Promise<void> {
     const injector = ReflectiveInjector.resolveAndCreate(this.providers);
-    const fooToken = injector.get(PROJECT_TOKEN);
+    const project = injector.get(PROJECT_TOKEN);
 
-    return buildNgPackage({ project: fooToken });
+    return buildNgPackage({ project });
   }
 
 }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -1,4 +1,5 @@
 export * from './lib/commands/command';
 export * from './lib/commands/build.command';
 export * from './lib/commands/version.command';
+export * from './lib/ng-v5/packagr';
 export * from './lib/deprecations';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,7 +2928,7 @@ rollup@^0.53.0:
   version "0.53.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.0.tgz#7a3d5a04ba2b0a8f2405899fa6a0ac48da480ed1"
 
-rxjs@^5.5.6:
+rxjs@^5.5.0:
   version "5.5.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,6 +1659,10 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
+injection-js@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/injection-js/-/injection-js-2.2.1.tgz#a8d6a085b2f0b8d8650f6f4487f6abb8cc0d67ce"
+
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -2924,9 +2928,9 @@ rollup@^0.53.0:
   version "0.53.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.0.tgz#7a3d5a04ba2b0a8f2405899fa6a0ac48da480ed1"
 
-rxjs@^5.4.0:
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.5.tgz#e164f11d38eaf29f56f08c3447f74ff02dd84e97"
+rxjs@^5.5.6:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
   dependencies:
     symbol-observable "1.0.1"
 


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Add `@stable` annotations to the command API.

Adds [`injection-js`](https://github.com/mgechev/injection-js) and [`rxjs`](https://github.com/ReactiveX/rxjs/tree/master/src) to dependencies of ng-packagr.

A step towards customizing through dependency injection. Future usage example:

```ts
ngPackagr()
  .withProviders([
    {
      provide: TSCONFIG_DEFAULTS,
      deps: [PROJECT_TOKEN],
      useFactory: (project: string) => {
        return { /* ... customize tsconfig for this verify specific project (?!?) */ };
      }
    }
  ])
  .build();
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
