### PR TITLE
feat: adding implementation and tests for resolving scss include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ Valid values: `none` or `inline`.
 }
 ```
 
-#### What if I have multiple SASS include paths?
+#### What if I have multiple SASS/SCSS include paths?
 
-If you have multiple include paths for SASS @import statements, such as when using the stylePreprocessorOptions in .angular-cli.json, you can
-configure the additional paths using the `sassIncludePaths` option.
+In case you have multiple include paths for `@import` statements (e.g., when setting the `stylePreprocessorOptions` in `.angular-cli.json`),
+the additional paths may be configured through the the `sassIncludePaths` option.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Create one `package.json` per npm package, run _ng-packagr_ for each!
  - :mag_right: Creates [scoped and non-scoped packages](https://docs.npmjs.com/misc/scope) for publishing to npm registry
  - :surfer: Inlines Templates and Stylesheets
  - :sparkles: CSS Features
-   - :camel: Runs [SCSS](http://sass-lang.com/guide) preprocessor, supporting the [relative `~` import syntax](https://github.com/webpack-contrib/sass-loader#imports)
+   - :camel: Runs [SCSS](http://sass-lang.com/guide) preprocessor, supporting the [relative `~` import syntax](https://github.com/webpack-contrib/sass-loader#imports) and custom include paths
    - :elephant: Runs [less](http://lesscss.org/#getting-started) preprocessor
    - :snake: Runs [Stylus](http://stylus-lang.com) preprocessor, resolves relative paths relative to ng-package.json
    - :monkey: Adds vendor-specific prefixes w/ [autoprefixer](https://github.com/postcss/autoprefixer#autoprefixer-) and [browserslist](https://github.com/ai/browserslist#queries) &mdash; just tell your desired `.browserslistrc`
@@ -202,6 +202,21 @@ Valid values: `none` or `inline`.
   "ngPackage": {
     "lib": {
       "cssUrl": "inline"
+    }
+  }
+}
+```
+
+#### What if I have multiple SASS include paths?
+
+If you have multiple include paths for SASS @import statements, such as when using the stylePreprocessorOptions in .angular-cli.json, you can
+configure the additional paths using the `sassIncludePaths` option.
+
+```json
+{
+  "ngPackage": {
+    "lib": {
+      "sassIncludePaths": ["./src/assets/styles"]
     }
   }
 }

--- a/integration/samples/scss-paths/.browserslistrc
+++ b/integration/samples/scss-paths/.browserslistrc
@@ -1,0 +1,3 @@
+last 2 Chrome versions
+iOS > 10
+Safari > 10

--- a/integration/samples/scss-paths/README.md
+++ b/integration/samples/scss-paths/README.md
@@ -1,0 +1,4 @@
+Sample library: Configuration in package.json
+======================================
+
+The configuration in this sample resides inside `package.json`.

--- a/integration/samples/scss-paths/assets/theme.scss
+++ b/integration/samples/scss-paths/assets/theme.scss
@@ -1,0 +1,1 @@
+$background-color-bright: "yellow";

--- a/integration/samples/scss-paths/baz/baz.component.html
+++ b/integration/samples/scss-paths/baz/baz.component.html
@@ -1,0 +1,1 @@
+<h1 class="baz">baz!</h1>

--- a/integration/samples/scss-paths/baz/baz.component.scss
+++ b/integration/samples/scss-paths/baz/baz.component.scss
@@ -1,0 +1,7 @@
+@import 'theme';
+@import '~node-sass/test/fixtures/include-files/file-not-processed-by-loader';
+
+.baz {
+    color: $variable-defined-by-file-not-processed-by-loader;
+    background-color: $background-color-bright;
+}

--- a/integration/samples/scss-paths/baz/baz.component.ts
+++ b/integration/samples/scss-paths/baz/baz.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'baz-component',
+  templateUrl: './baz.component.html',
+  styleUrls: ['./baz.component.scss']
+})
+export class BazComponent {
+}

--- a/integration/samples/scss-paths/package.json
+++ b/integration/samples/scss-paths/package.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../../../src/package.schema.json",
+  "name": "@sample/scss-paths",
+  "description": "A sample library that uses shared SCSS assets",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  },
+  "scripts": {
+    "test": "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public_api.ts",
+      "sassIncludePaths": ["./assets"]
+    }
+  }
+}

--- a/integration/samples/scss-paths/public_api.ts
+++ b/integration/samples/scss-paths/public_api.ts
@@ -1,0 +1,2 @@
+export * from './baz/baz.component';
+export * from './ui-lib.module';

--- a/integration/samples/scss-paths/specs/metadata.ts
+++ b/integration/samples/scss-paths/specs/metadata.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+
+describe(`@sample/scss-paths`, () => {
+
+  describe(`sample-scss-paths.metadata.json`, () => {
+    let METADATA;
+    before(() => {
+      METADATA = require('../dist/sample-scss-paths.metadata.json');
+    });
+
+    it(`should exist`, () => {
+      expect(METADATA).to.be.ok;
+    });
+
+    it(`should "importAs": "@sample/scss-paths"`, () => {
+      expect(METADATA['importAs']).to.equal('@sample/scss-paths');
+    });
+
+    it(`should resolve the styles from the theme`, () => {
+      const styles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][0];
+      expect(styles).to.contain(`color: "red"`);
+      expect(styles).to.contain(`background-color: "yellow"`);
+    });
+  });
+
+  describe(`scss-paths-sub-module.metadata.json`, () => {
+    let METADATA;
+    before(() => {
+      METADATA = require('../dist/sub-module/sample-scss-paths-sub-module.metadata.json');
+    });
+
+    it(`should exist`, () => {
+      expect(METADATA).to.be.ok;
+    });
+
+    it(`should "importAs": "@sample/scss-paths/sub-module"`, () => {
+      expect(METADATA['importAs']).to.equal('@sample/scss-paths/sub-module');
+    });
+
+    it(`should resolve the styles from the parent theme`, () => {
+      const styles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
+      expect(styles).to.contain(`background-color: "yellow"`);
+    });
+
+    it(`should resolve the styles from the sub-module common utilities`, () => {
+      const styles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
+      expect(styles).to.contain(`border: 10px solid "yellow"`);
+    });
+  });
+});

--- a/integration/samples/scss-paths/sub-module/.browserslistrc
+++ b/integration/samples/scss-paths/sub-module/.browserslistrc
@@ -1,0 +1,3 @@
+last 2 Chrome versions
+iOS > 10
+Safari > 10

--- a/integration/samples/scss-paths/sub-module/README.md
+++ b/integration/samples/scss-paths/sub-module/README.md
@@ -1,0 +1,4 @@
+Sample library: Configuration in package.json
+======================================
+
+The configuration in this sample resides inside `package.json`.

--- a/integration/samples/scss-paths/sub-module/assets/common.scss
+++ b/integration/samples/scss-paths/sub-module/assets/common.scss
@@ -1,0 +1,3 @@
+@mixin colored-border($color, $width) {
+    border: $width solid $color;
+}

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.html
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.html
@@ -1,0 +1,1 @@
+<h1 class="foo">bar!</h1>

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.scss
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.scss
@@ -1,0 +1,7 @@
+@import 'theme';
+@import 'common';
+
+.foo {
+    background-color: $background-color-bright;
+    @include colored-border($background-color-bright, 10px);
+}

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.ts
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'bar-component',
+  templateUrl: './bar.component.html',
+  styleUrls: ['./bar.component.scss']
+})
+export class BarComponent {
+}

--- a/integration/samples/scss-paths/sub-module/index.ts
+++ b/integration/samples/scss-paths/sub-module/index.ts
@@ -1,0 +1,2 @@
+export * from './bar/bar.component';
+export * from './ui-lib.module';

--- a/integration/samples/scss-paths/sub-module/package.json
+++ b/integration/samples/scss-paths/sub-module/package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../src/package.schema.json",
+  "name": "@sample/secondary/sub-module",
+  "description": "A sub module library",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "index.ts",
+      "sassIncludePaths": ["../assets","./assets"]
+    }
+  }
+}

--- a/integration/samples/scss-paths/sub-module/ui-lib.module.ts
+++ b/integration/samples/scss-paths/sub-module/ui-lib.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { BarComponent } from './bar/bar.component';
+
+@NgModule({
+  declarations: [
+    BarComponent,
+  ],
+  exports: [
+    BarComponent,
+  ]
+})
+export class UiLibModule {}

--- a/integration/samples/scss-paths/ui-lib.module.ts
+++ b/integration/samples/scss-paths/ui-lib.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { BazComponent } from './baz/baz.component';
+
+@NgModule({
+  declarations: [
+    BazComponent,
+  ],
+  exports: [
+    BazComponent,
+  ]
+})
+export class UiLibModule {}

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -84,6 +84,12 @@ export class NgEntryPoint {
     return this.$get('lib.flatModuleFile') || this.flattenModuleId('-');
   }
 
+  public get sassIncludePaths(): string[] {
+    const includePaths = this.$get('lib.sassIncludePaths') || [];
+    return includePaths.map(includePath =>
+      path.isAbsolute(includePath) ? includePath : path.resolve(this.basePath, includePath));
+  }
+
   /**
    * The module ID is an "identifier of a module used in the import statements, e.g.
    * '@angular/core'. The ID often maps directly to a path on the filesystem, but this

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -63,6 +63,13 @@
             "inline"
           ],
           "default": "none"
+        },
+        "sassIncludePaths": {
+          "description": "Any additional paths that should used to resolve SASS imports",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[X] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

Updates to the configuration under the `lib` element to add a new `sassIncludePaths` option, which takes an array of paths that will be used to resolve SCSS `@import` statements by the SASS compiler. If the paths are not absolute, they will be resolved relative to the ngPackage configuration file.

* Updated ng-package.schema.json to include the new option.
* Updated NgEntryPoint to read the property and resolve URLs relative to the package.
* Updated the assets step to pass the included paths to the SASS compiler.
* Added a new scss-paths integration test suite to ensure the SASS imports are working properly.
* Updated the README to include a new section on how to use the option.

To use the new option, users will add a `sassIncludePaths` section in the ngPackage configuration:

```json
{
  "ngPackage": {
    "lib": {
      "sassIncludePaths": ["./src/assets/styles"]
    }
  }
}
```

This pull request would resolve Issue #282 by adding the ability to include additional paths when resolving SCSS files from component imports.


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
