### PR TITLE
fix: strip comments from processed stylesheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jasmine": "^2.6.0",
     "json-schema-to-typescript": "^5.0.0",
     "mocha": "^5.0.0",
+    "postcss-discard-comments": "^2.0.4",
     "prettier": "^1.10.2",
     "pretty-quick": "^1.2.1",
     "react": "^16.0.0",

--- a/src/lib/steps/assets.ts
+++ b/src/lib/steps/assets.ts
@@ -15,6 +15,7 @@ import * as nodeSassTildeImporter from 'node-sass-tilde-importer';
 import * as less from 'less';
 import * as stylus from 'stylus';
 import * as postcssUrl from 'postcss-url';
+import * as postcssComments from 'postcss-discard-comments';
 
 export const processAssets: BuildStep =
   async ({ artefacts, entryPoint, pkg }): Promise<NgArtefacts> => {
@@ -85,7 +86,10 @@ const processStylesheet =
 
       if (cssUrl !== CssUrl.none) {
         log.debug(`postcssUrl: ${cssUrl}`);
-        postCssPlugins.push(postcssUrl({ url: cssUrl }));
+        postCssPlugins.push(
+          postcssUrl({ url: cssUrl }),
+          postcssComments({ removeAll: true })
+        );
       }
       const result: postcss.Result = await postcss(postCssPlugins)
         .process(cssStyles, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,6 +1647,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
@@ -1949,6 +1953,10 @@ jasmine@^2.6.0:
 js-base64@^2.1.8:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.0.tgz#9e566fee624751a1d720c966cd6226d29d4025aa"
+
+js-base64@^2.1.9:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.1.tgz#e02813181cd53002888e918935467acb2910e596"
 
 js-tokens@^3.0.0:
   version "3.0.2"
@@ -2688,6 +2696,12 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+postcss-discard-comments@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"
+  dependencies:
+    postcss "^5.0.14"
+
 postcss-url@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-7.3.0.tgz#cf2f45e06743cf43cfea25309f81cbc003dc783f"
@@ -2701,6 +2715,15 @@ postcss-url@^7.3.0:
 postcss-value-parser@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss@^5.0.14:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
 
 postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.2:
   version "6.0.14"
@@ -3397,6 +3420,12 @@ supports-color@4.4.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^4.0.0, supports-color@^4.4.0:
   version "4.5.0"


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Removes comments from processed stylesheets. Also fixes #503 since if back ticks were in stylesheets, it broke builds. See #503 for more details.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
