### PR TITLE
fix: dispose the previous TransformationResult after inlining

### DIFF
--- a/src/lib/ng-package-format/artefacts.ts
+++ b/src/lib/ng-package-format/artefacts.ts
@@ -52,12 +52,6 @@ export class NgArtefacts {
     this.extras('tsSources', value);
   }
 
-  public tsSyntheticSourcFiles(): ts.SourceFile[] {
-    return Array.from(this._extras.keys())
-      .filter(key => key.startsWith('ts:'))
-      .map(key => <ts.SourceFile>this.extras(key));
-  }
-
   public template(file: string): string;
   public template(file: string, content: string);
   public template(file: string, content?: string): string | undefined {

--- a/src/lib/steps/entry-point-transforms.ts
+++ b/src/lib/steps/entry-point-transforms.ts
@@ -6,7 +6,7 @@ import { NgPackage } from '../ng-package-format/package';
 import { BuildStep } from '../deprecations';
 import { writePackage } from '../steps/package';
 import { processAssets } from '../steps/assets';
-import { ngc, collectTemplateAndStylesheetFiles, inlineTemplatesAndStyles } from '../steps/ngc';
+import { ngc, extractTemplateAndStylesheetFiles, inlineTemplatesAndStyles } from '../steps/ngc';
 import { FlattenOpts, writeFlatBundleFiles } from '../flatten/flatten';
 import { relocateSourceMaps } from '../sourcemaps/relocate';
 import { copySourceFilesToDestination } from '../steps/transfer';
@@ -35,7 +35,7 @@ export function transformSourcesFactory(prepareTsConfig: BuildStep) {
 
     // First pass: collect templateUrl and styleUrls referencing source files.
     log.info('Extracting templateUrl and styleUrls');
-    collectTemplateAndStylesheetFiles(args);
+    extractTemplateAndStylesheetFiles(args);
 
     // Then, process assets keeping transformed contents in memory.
     log.info('Processing assets');

--- a/src/lib/ts/synthesized-compiler-host.ts
+++ b/src/lib/ts/synthesized-compiler-host.ts
@@ -18,21 +18,21 @@ export function createCompilerHostForSynthesizedSourceFiles(
   return {
     ...wrapped,
     getSourceFile: (fileName, version) => {
-      const fromCollection = sourceFiles.find(file => file.fileName === fileName);
+      const sourceFile = sourceFiles.find(file => file.fileName === fileName);
 
-      if (fromCollection) {
+      if (sourceFile) {
         // FIX @link https://github.com/Microsoft/TypeScript/issues/19950
-        if (!fromCollection['ambientModuleNames']) {
-          fromCollection['ambientModuleNames'] = fromCollection['original']['ambientModuleNames'];
+        if (!sourceFile['ambientModuleNames'] && sourceFile['original']) {
+          sourceFile['ambientModuleNames'] = sourceFile['original']['ambientModuleNames'];
         }
 
         // FIX synthesized source files cause ngc/tsc/tsickle to chock
-        const hasSyntheticFlag = (fromCollection.flags & 8) !== 0;
-        if (hasSyntheticFlag || isSynthesizedSourceFile(fromCollection)) {
-          return writeSourceFile(fromCollection);
+        const hasSyntheticFlag = (sourceFile.flags & 8) !== 0;
+        if (hasSyntheticFlag || isSynthesizedSourceFile(sourceFile)) {
+          return writeSourceFile(sourceFile);
         }
 
-        return fromCollection;
+        return sourceFile;
       } else {
         return wrapped.getSourceFile(fileName, version);
       }

--- a/src/lib/ts/transform-component.ts
+++ b/src/lib/ts/transform-component.ts
@@ -1,14 +1,23 @@
 import * as ts from 'typescript';
 import { isComponentDecorator, isTemplateUrl, isStyleUrls } from './ng-type-guards';
 
-export type ComponentVisitors = {
-  templateVisitor: ts.Transformer<ts.PropertyAssignment>;
-  stylesheetVisitor: ts.Transformer<ts.PropertyAssignment>;
+/**
+ * A transformer that updates the metadata for Angular `@Component({})` decorators.
+ */
+export type ComponentTransformer = {
+  /** TypeScript transformer to update the property assignment for `templateUrl: '..'`. */
+  templateUrl: ts.Transformer<ts.PropertyAssignment>;
+
+  /** TypeScript transformer to update the property assignment for `styleUrls: []`. */
+  stylesheetUrl: ts.Transformer<ts.PropertyAssignment>;
+
+  /** TypeScript transformer to update the source file. */
+  file?: ts.Transformer<ts.SourceFile>;
 };
 
-export const transformComponent = ({ templateVisitor, stylesheetVisitor }: ComponentVisitors) => (
-  context: ts.TransformationContext
-) => (sourceFile: ts.SourceFile): ts.SourceFile => {
+export const transformComponent = (transformer: ComponentTransformer) => (context: ts.TransformationContext) => (
+  sourceFile: ts.SourceFile
+): ts.SourceFile => {
   // skip source files from 'node_modules' directory (third-party source)
   if (sourceFile.fileName.includes('node_modules')) {
     return sourceFile;
@@ -16,9 +25,9 @@ export const transformComponent = ({ templateVisitor, stylesheetVisitor }: Compo
 
   const visitComponentMetadata: ts.Visitor = (node: ts.Decorator) => {
     if (isTemplateUrl(node)) {
-      return templateVisitor(node);
+      return transformer.templateUrl(node);
     } else if (isStyleUrls(node)) {
-      return stylesheetVisitor(node);
+      return transformer.stylesheetUrl(node);
     }
 
     return ts.visitEachChild(node, visitComponentMetadata, context);
@@ -29,5 +38,8 @@ export const transformComponent = ({ templateVisitor, stylesheetVisitor }: Compo
       ? ts.visitEachChild(node, visitComponentMetadata, context)
       : ts.visitEachChild(node, visitDecorators, context);
 
-  return ts.visitNode(sourceFile, visitDecorators);
+  // Either custom file transformer or identity transform
+  const transformFile = transformer.file ? transformer.file : file => file;
+
+  return transformFile(ts.visitNode(sourceFile, visitDecorators));
 };


### PR DESCRIPTION

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Tests unchanged. Specs should be green, so considered to be non-breaking.

Beside, re-write the `transformComponent` and `ComponenTransformer` APIs. They might become public.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
