### PR TITLE
fix: css comments should be discarded irrespective of `cssUrl`

### DIFF
--- a/src/lib/steps/assets.ts
+++ b/src/lib/steps/assets.ts
@@ -82,15 +82,16 @@ const processStylesheet =
       const browsers = browserslist(undefined, { stylesheetFilePath });
 
       log.debug(`postcss with autoprefixer for ${stylesheetFilePath}`);
-      const postCssPlugins = [autoprefixer({ browsers })];
+      const postCssPlugins = [
+        autoprefixer({ browsers }),
+        postcssComments({ removeAll: true })
+      ];
 
       if (cssUrl !== CssUrl.none) {
         log.debug(`postcssUrl: ${cssUrl}`);
-        postCssPlugins.push(
-          postcssUrl({ url: cssUrl }),
-          postcssComments({ removeAll: true })
-        );
+        postCssPlugins.push(postcssUrl({ url: cssUrl }));
       }
+
       const result: postcss.Result = await postcss(postCssPlugins)
         .process(cssStyles, {
           from: stylesheetFilePath,

--- a/src/lib/steps/assets.ts
+++ b/src/lib/steps/assets.ts
@@ -82,15 +82,17 @@ const processStylesheet =
       const browsers = browserslist(undefined, { stylesheetFilePath });
 
       log.debug(`postcss with autoprefixer for ${stylesheetFilePath}`);
-      const postCssPlugins = [
-        autoprefixer({ browsers }),
-        postcssComments({ removeAll: true })
-      ];
+      const postCssPlugins = [];
 
       if (cssUrl !== CssUrl.none) {
         log.debug(`postcssUrl: ${cssUrl}`);
         postCssPlugins.push(postcssUrl({ url: cssUrl }));
       }
+
+      postCssPlugins.push(
+        autoprefixer({ browsers }),
+        postcssComments({ removeAll: true })
+      );
 
       const result: postcss.Result = await postcss(postCssPlugins)
         .process(cssStyles, {


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description
fix: css comments should be discarded irrespective of `cssUrl`
## Does this PR introduce a breaking change?

