### PR TITLE
fix: css comments should be discarded irrespective of `cssUrl`

### DIFF
--- a/integration/samples/custom/specs/metadata.ts
+++ b/integration/samples/custom/specs/metadata.ts
@@ -32,8 +32,8 @@ describe(`sample-custom`, () => {
       expect(foo).to.be.ok;
       expect(foo.selector).to.equal('custom-foo');
       expect(foo.template).to.contain('<h1>Foo!</h1>');
-      expect(foo.styles[0]).to.contain('h1 {');
-      expect(foo.styles[0]).to.contain('color: #ff0000; }');
+      expect(foo.styles[0]).to.contain('h1{');
+      expect(foo.styles[0]).to.contain('color:#ff0000; }');
     });
 
     describe(`BazComponent`, () => {
@@ -59,16 +59,16 @@ describe(`sample-custom`, () => {
       const foo = METADATA['metadata']['FooComponent']['decorators'][0]['arguments'][0];
 
       expect(foo).to.be.ok;
-      expect(foo.styles[0]).to.contain(`color: #ff0000`);
-      expect(foo.styles[0]).to.not.contain(`$color: #ff0000`);
+      expect(foo.styles[0]).to.contain(`color:#ff0000`);
+      expect(foo.styles[0]).to.not.contain(`$color:#ff0000`);
     });
 
     it(`should contain less-rendered styles`, () => {
       const baz = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0];
 
       expect(baz).to.be.ok;
-      expect(baz.styles[0]).to.contain(`color: #ff0000`);
-      expect(baz.styles[0]).to.not.contain(`@red: #ff0000`);
+      expect(baz.styles[0]).to.contain(`color:#ff0000`);
+      expect(baz.styles[0]).to.not.contain(`@red:#ff0000`);
     });
 
     describe(`stylus styles`, () => {
@@ -76,24 +76,24 @@ describe(`sample-custom`, () => {
         const fooBar = METADATA['metadata']['FooBarComponent']['decorators'][0]['arguments'][0];
 
         expect(fooBar).to.be.ok;
-        expect(fooBar.styles[0]).to.contain(`color: #f00;`);
-        expect(fooBar.styles[0]).to.not.contain(`color: $color`);
+        expect(fooBar.styles[0]).to.contain(`color:#f00;`);
+        expect(fooBar.styles[0]).to.not.contain(`color:$color`);
       });
 
       it(`should contain imported styles`, () => {
         const fooBar = METADATA['metadata']['FooBarComponent']['decorators'][0]['arguments'][0];
 
         expect(fooBar).to.be.ok;
-        expect(fooBar.styles[0]).to.contain(`background-color: #008000;`);
-        expect(fooBar.styles[0]).to.not.contain(`background-color: $color-green;`);
+        expect(fooBar.styles[0]).to.contain(`background-color:#008000;`);
+        expect(fooBar.styles[0]).to.not.contain(`background-color:$color-green;`);
       });
 
       it(`should contain imported image path`, () => {
         const fooBar = METADATA['metadata']['FooBarComponent']['decorators'][0]['arguments'][0];
 
         expect(fooBar).to.be.ok;
-        expect(fooBar.styles[0]).to.contain(`background-image: url("../styles/assets/test.png");`);
-        expect(fooBar.styles[0]).to.not.contain(`background-color: url(./assets/test.png);`);
+        expect(fooBar.styles[0]).to.contain(`background-image:url("../styles/assets/test.png");`);
+        expect(fooBar.styles[0]).to.not.contain(`background-color:url(./assets/test.png);`);
       });
     });
 

--- a/integration/samples/material/specs/metadata.ts
+++ b/integration/samples/material/specs/metadata.ts
@@ -36,10 +36,10 @@ describe(`@sample/material`, () => {
       });
 
       it(`should have style with: "color: red"`, () => {
-        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('color: "red"');
+        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('color:"red"');
       });
       it(`should have style with: "content: \\2014 \\00A0"`, () => {
-        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('content: "\\2014 \\00A0"');
+        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('content:"\\2014 \\00A0"');
       });
     });
 

--- a/integration/samples/scss-paths/specs/metadata.ts
+++ b/integration/samples/scss-paths/specs/metadata.ts
@@ -18,8 +18,8 @@ describe(`@sample/scss-paths`, () => {
 
     it(`should resolve the styles from the theme`, () => {
       const styles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(styles).to.contain(`color: "red"`);
-      expect(styles).to.contain(`background-color: "yellow"`);
+      expect(styles).to.contain(`color:"red"`);
+      expect(styles).to.contain(`background-color:"yellow"`);
     });
   });
 
@@ -39,12 +39,12 @@ describe(`@sample/scss-paths`, () => {
 
     it(`should resolve the styles from the parent theme`, () => {
       const styles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(styles).to.contain(`background-color: "yellow"`);
+      expect(styles).to.contain(`background-color:"yellow"`);
     });
 
     it(`should resolve the styles from the sub-module common utilities`, () => {
       const styles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(styles).to.contain(`border: 10px solid "yellow"`);
+      expect(styles).to.contain(`border:10px solid "yellow"`);
     });
   });
 });

--- a/src/lib/steps/assets.ts
+++ b/src/lib/steps/assets.ts
@@ -82,15 +82,16 @@ const processStylesheet =
       const browsers = browserslist(undefined, { stylesheetFilePath });
 
       log.debug(`postcss with autoprefixer for ${stylesheetFilePath}`);
-      const postCssPlugins = [autoprefixer({ browsers })];
+      const postCssPlugins = [
+        autoprefixer({ browsers }),
+        postcssComments({ removeAll: true })
+      ];
 
       if (cssUrl !== CssUrl.none) {
         log.debug(`postcssUrl: ${cssUrl}`);
-        postCssPlugins.push(
-          postcssUrl({ url: cssUrl }),
-          postcssComments({ removeAll: true })
-        );
+        postCssPlugins.push(postcssUrl({ url: cssUrl }));
       }
+
       const result: postcss.Result = await postcss(postCssPlugins)
         .process(cssStyles, {
           from: stylesheetFilePath,


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description
fix: css comments should be discarded irrespective of `cssUrl`
## Does this PR introduce a breaking change?

