### PR TITLE
feat: reduce library bundle size by clean-css

### DIFF
--- a/integration/samples/custom/specs/metadata.ts
+++ b/integration/samples/custom/specs/metadata.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe(`sample-custom`, () => {
-
   describe(`sample-custom.metadata.json`, () => {
     let METADATA;
     before(() => {
@@ -33,7 +32,7 @@ describe(`sample-custom`, () => {
       expect(foo.selector).to.equal('custom-foo');
       expect(foo.template).to.contain('<h1>Foo!</h1>');
       expect(foo.styles[0]).to.contain('h1{');
-      expect(foo.styles[0]).to.contain('color:#ff0000; }');
+      expect(foo.styles[0]).to.contain('color:red}');
     });
 
     describe(`BazComponent`, () => {
@@ -44,14 +43,16 @@ describe(`sample-custom`, () => {
 
       it(`should be exported`, () => {
         expect(baz).to.be.ok;
-      })
+      });
 
       it(`should have the <h1> template inlined`, () => {
         expect(baz.template).to.satisfy(str => str.startsWith(`<h1 class="supersized">Baz!</h1>`));
       });
 
       it(`should have a styles array with two stylesheets`, () => {
-        expect(baz.styles).to.be.an('array').that.has.length(2);
+        expect(baz.styles)
+          .to.be.an('array')
+          .that.has.length(2);
       });
     });
 
@@ -59,7 +60,7 @@ describe(`sample-custom`, () => {
       const foo = METADATA['metadata']['FooComponent']['decorators'][0]['arguments'][0];
 
       expect(foo).to.be.ok;
-      expect(foo.styles[0]).to.contain(`color:#ff0000`);
+      expect(foo.styles[0]).to.contain(`color:red`);
       expect(foo.styles[0]).to.not.contain(`$color:#ff0000`);
     });
 
@@ -67,7 +68,7 @@ describe(`sample-custom`, () => {
       const baz = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0];
 
       expect(baz).to.be.ok;
-      expect(baz.styles[0]).to.contain(`color:#ff0000`);
+      expect(baz.styles[0]).to.contain(`color:red`);
       expect(baz.styles[0]).to.not.contain(`@red:#ff0000`);
     });
 
@@ -76,15 +77,15 @@ describe(`sample-custom`, () => {
         const fooBar = METADATA['metadata']['FooBarComponent']['decorators'][0]['arguments'][0];
 
         expect(fooBar).to.be.ok;
-        expect(fooBar.styles[0]).to.contain(`color:#f00;`);
-        expect(fooBar.styles[0]).to.not.contain(`color:$color`);
+        expect(fooBar.styles[0]).to.contain(`color:red`);
+        expect(fooBar.styles[0]).to.not.contain(`$color`);
       });
 
       it(`should contain imported styles`, () => {
         const fooBar = METADATA['metadata']['FooBarComponent']['decorators'][0]['arguments'][0];
 
         expect(fooBar).to.be.ok;
-        expect(fooBar.styles[0]).to.contain(`background-color:#008000;`);
+        expect(fooBar.styles[0]).to.contain(`background-color:green;`);
         expect(fooBar.styles[0]).to.not.contain(`background-color:$color-green;`);
       });
 
@@ -92,12 +93,10 @@ describe(`sample-custom`, () => {
         const fooBar = METADATA['metadata']['FooBarComponent']['decorators'][0]['arguments'][0];
 
         expect(fooBar).to.be.ok;
-        expect(fooBar.styles[0]).to.contain(`background-image:url("../styles/assets/test.png");`);
-        expect(fooBar.styles[0]).to.not.contain(`background-color:url(./assets/test.png);`);
+        expect(fooBar.styles[0]).to.contain(`background-image:url(../styles/assets/test.png)`);
+        expect(fooBar.styles[0]).to.not.contain(`background-color:url(./assets/test.png)`);
       });
     });
-
-
 
     it(`should re-export 'InternalService' with an auto-generated symbol`, () => {
       expect(METADATA['metadata']['ɵa']).to.be.ok;

--- a/integration/samples/material/specs/metadata.ts
+++ b/integration/samples/material/specs/metadata.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe(`@sample/material`, () => {
-
   describe(`material.metadata.json`, () => {
     let METADATA;
     before(() => {
@@ -36,12 +35,14 @@ describe(`@sample/material`, () => {
       });
 
       it(`should have style with: "color: red"`, () => {
-        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('color:"red"');
+        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('color:red');
       });
+
       it(`should have style with: "content: \\2014 \\00A0"`, () => {
-        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string('content:"\\2014 \\00A0"');
+        expect(METADATA['metadata'].BazComponent.decorators[0].arguments[0].styles[0]).to.have.string(
+          'content:"\\2014 \\00A0"'
+        );
       });
     });
-
   });
 });

--- a/integration/samples/scss-paths/specs/metadata.ts
+++ b/integration/samples/scss-paths/specs/metadata.ts
@@ -17,14 +17,14 @@ describe(`@sample/scss-paths`, () => {
 
     it(`should resolve the styles from the SCSS theme`, () => {
       const scssStyles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(scssStyles).to.contain(`color:"red"`);
-      expect(scssStyles).to.contain(`background-color:"yellow"`);
+      expect(scssStyles).to.contain(`color:red`);
+      expect(scssStyles).to.contain(`background-color:yellow`);
     });
 
     it(`should resolve the styles from the Less theme`, () => {
       const lessStyles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][1];
       expect(lessStyles).to.contain(`.baz .oom`);
-      expect(lessStyles).to.contain(`color:'red'`);
+      expect(lessStyles).to.contain(`color:red`);
     });
 
     it(`should resolve the styles from the Stylus theme`, () => {
@@ -49,22 +49,22 @@ describe(`@sample/scss-paths`, () => {
 
     it(`should resolve the SCSS styles from the parent theme`, () => {
       const scssStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(scssStyles).to.contain(`background-color:"yellow"`);
+      expect(scssStyles).to.contain(`background-color:yellow`);
     });
 
     it(`should resolve the SCSS styles from the sub-module common utilities`, () => {
       const scssStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(scssStyles).to.contain(`border:10px solid "yellow"`);
+      expect(scssStyles).to.contain(`border:10px solid yellow`);
     });
 
     it(`should resolve the Less styles from the parent theme`, () => {
       const lessStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][1];
-      expect(lessStyles).to.contain(`color:'red'`);
+      expect(lessStyles).to.contain(`color:red`);
     });
 
     it(`should resolve the Less styles from the sub-module common utilities`, () => {
       const lessStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][1];
-      expect(lessStyles).to.contain(`font-weight:bold`);
+      expect(lessStyles).to.contain(`font-weight:700`);
     });
 
     it(`should resolve the Stylus styles from the parent theme`, () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-sass": "^4.5.3",
     "node-sass-tilde-importer": "^1.0.0",
     "postcss": "^6.0.2",
-    "postcss-discard-comments": "^2.0.4",
+    "postcss-clean": "^1.1.0",
     "postcss-url": "^7.3.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.55.0",

--- a/src/lib/ng-v5/entry-point/resources/template.transform.ts
+++ b/src/lib/ng-v5/entry-point/resources/template.transform.ts
@@ -38,5 +38,6 @@ export const templateTransform: Transform = transformFromPromise(async graph => 
 async function processTemplate(templateFilePath: string): Promise<string> {
   const buffer = await readFile(templateFilePath);
 
-  return stripBom(buffer.toString());
+  // drop line-breaks of the content
+  return stripBom(buffer.toString().replace(/([\n\r]\s*)+/gm, ' '));
 }

--- a/src/lib/ng-v5/entry-point/resources/template.transform.ts
+++ b/src/lib/ng-v5/entry-point/resources/template.transform.ts
@@ -38,6 +38,5 @@ export const templateTransform: Transform = transformFromPromise(async graph => 
 async function processTemplate(templateFilePath: string): Promise<string> {
   const buffer = await readFile(templateFilePath);
 
-  // drop line-breaks of the content
-  return stripBom(buffer.toString().replace(/([\n\r]\s*)+/gm, ' '));
+  return stripBom(buffer.toString());
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,7 +349,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -662,6 +662,14 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -684,6 +692,12 @@ chokidar@^1.4.2, chokidar@^1.6.0, chokidar@^1.7.0:
 ci-info@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
+clean-css@^4.x:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
+  dependencies:
+    source-map "0.5.x"
 
 cli-color@^1.2.0:
   version "1.2.0"
@@ -1579,13 +1593,13 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1860,7 +1874,7 @@ jasmine@^3.0.0:
     glob "^7.0.6"
     jasmine-core "~3.0.0"
 
-js-base64@^2.1.8, js-base64@^2.1.9:
+js-base64@^2.1.8:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.1.tgz#e02813181cd53002888e918935467acb2910e596"
 
@@ -2598,11 +2612,12 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-postcss-discard-comments@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"
+postcss-clean@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-clean/-/postcss-clean-1.1.0.tgz#c2d61d5d8caf19a585adba16897726c2674c4207"
   dependencies:
-    postcss "^5.0.14"
+    clean-css "^4.x"
+    postcss "^6.x"
 
 postcss-url@^7.3.0:
   version "7.3.0"
@@ -2618,15 +2633,6 @@ postcss-value-parser@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
-postcss@^5.0.14:
-  version "5.2.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
-  dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
 postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.2:
   version "6.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
@@ -2634,6 +2640,14 @@ postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.2:
     chalk "^2.3.0"
     source-map "^0.6.1"
     supports-color "^4.4.0"
+
+postcss@^6.x:
+  version "6.0.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.18.tgz#370f5f44d47f3a205f0eb2f6262bbf202df2a80e"
+  dependencies:
+    chalk "^2.3.1"
+    source-map "^0.6.1"
+    supports-color "^5.2.0"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -3118,15 +3132,15 @@ source-map@0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
-
-source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
@@ -3300,17 +3314,17 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  dependencies:
-    has-flag "^1.0.0"
-
 supports-color@^4.0.0, supports-color@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
 
 symbol-observable@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description
At that moment, `css` and `html` within components cannot be optimized by the consumers by using `Webpack`, `Angular Build Optimizer` or any other tool that bundles simply because these optimization have to happen at a library level when the the transformation happens that turns these assets into strings in the `JS` file

Reduce final bundle size by;
- Using `cleanCss` this will remove comments, new lines, extra quotes among others
- Remove new lines in `HTML` templates as these don't have any effect in the browser

Other component libraries are doing the same. Apart from `preserveWhitespaces` (Which in this case the library develop can do)
https://github.com/angular/material2/blob/73bc948faaf4f3a566256e5e733109f9847bb252/src/lib/button/button.ts#L73

they also have the trim breaklines
https://github.com/angular/material2/blob/73bc948faaf4f3a566256e5e733109f9847bb252/tools/package-tools/inline-resources.ts#L53

https://github.com/angular/material2/blob/73bc948faaf4f3a566256e5e733109f9847bb252/tools/package-tools/gulp/build-scss-task.ts#L14

example
```js
    SkeletonComponent.decorators = [
        { type: core.Component, args: [{
                    selector: "obg-skeleton",
                    template: "<h1>Sample</h1>\n\n<p>some text</p>",
                    styles: [":host {\n  display: block; }\n"]
                },] },
    ];
```
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Closes: https://github.com/dherges/ng-packagr/issues/614