### PR TITLE
fix: strip bom from processed assets (#487)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rxjs": "^5.5.0",
     "sorcery": "^0.10.0",
+    "strip-bom": "^3.0.0",
     "stylus": "^0.54.5",
     "uglify-js": "^3.0.7"
   },
@@ -80,6 +81,7 @@
     "@types/react-dom": "^16.0.2",
     "@types/rollup": "^0.51.2",
     "@types/sinon": "^4.0.0",
+    "@types/strip-bom": "^3.0.0",
     "chai": "^4.0.1",
     "copyfiles": "^1.2.0",
     "cross-env": "^5.0.5",
@@ -111,14 +113,11 @@
     "publish:ci": "yarn prerelease && yarn postrelease",
     "integration:samples": "integration/samples.sh",
     "integration:samples:dev": "ts-node --project src/tsconfig.packagr.json ./integration/samples.dev.ts",
-    "integration:specs":
-      "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register integration/samples/*/specs/**/*.ts",
+    "integration:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register integration/samples/*/specs/**/*.ts",
     "integration:consumers": "integration/consumers.sh",
     "integration:consumers:ngc": "ngc -p integration/consumers/tsc/tsconfig.json",
-    "test:specs":
-      "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register 'src/**/*.spec.ts'",
-    "test":
-      "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:consumers",
+    "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register \"src/**/*.spec.ts\"",
+    "test": "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:consumers",
     "commitmsg": "commitlint -e",
     "precommit": "pretty-quick --staged",
     "gh-pages": "gh-pages -d docs/ghpages"

--- a/src/lib/ng-v5/entry-point/resources/stylesheet.transform.ts
+++ b/src/lib/ng-v5/entry-point/resources/stylesheet.transform.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import stripBom = require('strip-bom');
 import { Transform, transformFromPromise } from '../../../brocc/transform';
 import { NgEntryPoint, CssUrl } from '../../../ng-package-format/entry-point';
 import * as log from '../../../util/log';
@@ -103,7 +104,7 @@ async function renderPreProcessor(filePath: string, basePath: string, entryPoint
     case '.css':
     default:
       log.debug(`reading css from ${filePath}`);
-      return fs.readFile(filePath).then(buffer => buffer.toString());
+      return fs.readFile(filePath).then(buffer => stripBom(buffer.toString()));
   }
 }
 
@@ -122,7 +123,7 @@ const renderSass = (sassOpts: any): Promise<string> => {
 const renderLess = (lessOpts: any): Promise<string> => {
   return fs
     .readFile(lessOpts.filename)
-    .then(buffer => buffer.toString())
+    .then(buffer => stripBom(buffer.toString()))
     .then(
       (lessData: string) =>
         new Promise<string>((resolve, reject) => {
@@ -144,7 +145,7 @@ const renderLess = (lessOpts: any): Promise<string> => {
 const renderStylus = ({ filename, root }): Promise<string> => {
   return fs
     .readFile(filename)
-    .then(buffer => buffer.toString())
+    .then(buffer => stripBom(buffer.toString()))
     .then(
       (stylusData: string) =>
         new Promise<string>((resolve, reject) => {

--- a/src/lib/ng-v5/entry-point/resources/template.transform.ts
+++ b/src/lib/ng-v5/entry-point/resources/template.transform.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'fs-extra';
 import { map } from 'rxjs/operators';
 import { pipe } from 'rxjs/util/pipe';
+import stripBom = require('strip-bom');
 import { Transform, transformFromPromise } from '../../../brocc/transform';
 import * as log from '../../../util/log';
 import { byEntryPoint, isInProgress } from '../../entry-point.node';
@@ -35,5 +36,7 @@ export const templateTransform: Transform = transformFromPromise(async graph => 
  * @return Resolved content of HTML template file
  */
 async function processTemplate(templateFilePath: string): Promise<string> {
-  return (await readFile(templateFilePath)).toString();
+  const buffer = await readFile(templateFilePath);
+
+  return stripBom(buffer.toString());
 }


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist


fix: strip BOM from processed assets (#487)


## Description

use [strip-bom](https://github.com/sindresorhus/strip-bom) package to remove byte order mark from the string of processed assets, and add it to dependencies in package.json

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
