### PR TITLE
perf: don't await and return

### DIFF
--- a/src/lib/ng-v5/entry-point/resources/stylesheet.transform.ts
+++ b/src/lib/ng-v5/entry-point/resources/stylesheet.transform.ts
@@ -86,7 +86,7 @@ async function renderPreProcessor(filePath: string, basePath: string, entryPoint
     case '.scss':
     case '.sass':
       log.debug(`rendering sass from ${filePath}`);
-      return await renderSass({
+      return renderSass({
         file: filePath,
         importer: nodeSassTildeImporter,
         includePaths: entryPoint.sassIncludePaths
@@ -94,12 +94,12 @@ async function renderPreProcessor(filePath: string, basePath: string, entryPoint
 
     case '.less':
       log.debug(`rendering less from ${filePath}`);
-      return await renderLess({ filename: filePath });
+      return renderLess({ filename: filePath });
 
     case '.styl':
     case '.stylus':
       log.debug(`rendering styl from ${filePath}`);
-      return await renderStylus({ filename: filePath, root: basePath });
+      return renderStylus({ filename: filePath, root: basePath });
 
     case '.css':
     default:

--- a/src/lib/util/json.ts
+++ b/src/lib/util/json.ts
@@ -11,9 +11,8 @@ import { debug } from './log';
  *                  that will be JSON-stringified
  */
 export async function modifyJsonFiles(globPattern: string, modifyFn: (jsonObj: any) => any): Promise<void> {
-
   debug('modifyJsonFiles');
-  const fileNames: string[] = await promisify<string[]>((resolveOrReject) => {
+  const fileNames: string[] = await promisify<string[]>(resolveOrReject => {
     glob(globPattern, resolveOrReject);
   });
 
@@ -22,8 +21,8 @@ export async function modifyJsonFiles(globPattern: string, modifyFn: (jsonObj: a
       const fileContent: any = await tryReadJson(fileName);
       const modified = modifyFn(fileContent);
       await writeJson(fileName, modified, { spaces: 2 });
-    }
-  ));
+    })
+  );
 }
 
 /**
@@ -33,9 +32,9 @@ export async function modifyJsonFiles(globPattern: string, modifyFn: (jsonObj: a
  */
 export async function tryReadJson(filePath: string): Promise<any> {
   try {
-    return await readJson(filePath);
+    return readJson(filePath);
   } catch (e) {
     // this means the file was empty or not json, which is fine
-    return await Promise.resolve({});
+    return Promise.resolve({});
   }
 }


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
Minor thing

An async function always wraps the return value in a Promise. Using return await just adds extra time before the overreaching promise is resolved without changing the semantics


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
