### PR TITLE
feat: export and test public api surface

### DIFF
--- a/src/lib/brocc/transform.di.ts
+++ b/src/lib/brocc/transform.di.ts
@@ -1,10 +1,45 @@
 import { InjectionToken, FactoryProvider } from 'injection-js';
+import { Transform } from './transform';
 
+/**
+ * A specialized `FactoryProvider` for a `Transform`.
+ */
 export interface TransformProvider extends FactoryProvider {
-  provide: InjectionToken<any>;
-  deps?: any[];
+  /**
+   * An injection token for the `Transform` provided by this provider.
+   */
+  provide: InjectionToken<Transform>;
+
+  /**
+   * A function to invoke to create the `Transform`.
+   *
+   * The factory function is invoked with resolved values of tokens in the `deps` field.
+   */
+  useFactory: (...args: any[]) => Transform;
 }
 
+/**
+ * Creates a provider for a `Transform`.
+ *
+ * #### Example
+ *
+ * Creating a transformation `fooBar` that is composed of `foo` and `bar` transforms:
+ *
+ * ```ts
+ * const FOO_BAR_TOKEN = new InjectionToken<Transform>('fooBar');
+ *
+ * const FOO_BAR_TRANSFORM provideTransform({
+ *   provide: FOO_BAR_TOKEN,
+ *   useFactory: (foo, bar) => {
+ *     return pipe(foo, bar);
+ *   },
+ *   deps: [ FOO_TOKEN, BAR_TOKEN ]
+ * });
+ * ```
+ *
+ * @param module The provider for the transform
+ * @return A (normalized) provider for the transform
+ */
 export function provideTransform(module: TransformProvider): TransformProvider {
   return {
     ...module,

--- a/src/lib/commands/build.command.ts
+++ b/src/lib/commands/build.command.ts
@@ -1,13 +1,21 @@
 import { Command } from './command';
 import { ngPackagr } from '../ng-v5/packagr';
 
-/** CLI arguments passed to `ng-packagr` executable and `build()` command. */
+/**
+ * CLI arguments passed to `ng-packagr` executable and `build()` command.
+ *
+ * @stable
+ */
 export interface CliArguments {
   /** Path to the project file 'package.json', 'ng-package.json', or 'ng-package.js'. */
   project: string;
 }
 
-/** @stable */
+/**
+ * Command running an "one-off" build.
+ *
+ * @stable
+ */
 export const build: Command<CliArguments, void> = opts =>
   ngPackagr()
     .forProject(opts.project)

--- a/src/lib/commands/command.ts
+++ b/src/lib/commands/command.ts
@@ -1,15 +1,18 @@
 /**
- * Common call signature for a command
+ * Common call signature for a command.
  *
  * @stable
  */
 export interface Command<Arguments, Result> {
-  (args?: Arguments): Result | Promise<Result>
+  (args?: Arguments): Result | Promise<Result>;
 }
 
-/** @stable */
+/**
+ * Executes a Command and returns its promisified result.
+ *
+ * @stable
+ */
 export function execute<A, R>(command: Command<A, R>, args?: A): Promise<R> {
-
   const result = args ? command(args) : command();
   if (result instanceof Promise) {
     return result;

--- a/src/lib/commands/version.command.ts
+++ b/src/lib/commands/version.command.ts
@@ -16,22 +16,25 @@ function tryReadVersion(paths: string[] = []) {
     if (PKG.name === 'ng-packagr') {
       NG_PACKAGR_VERSION = PKG.version;
     } else {
-      tryReadVersion(paths)
+      tryReadVersion(paths);
     }
   } catch (e) {
     tryReadVersion(paths);
   }
 }
 
-/** @stable */
-export const version: Command<undefined, void> =
-  () => {
-    tryReadVersion(['../../package.json', '../../../package.json']);
+/**
+ * Prints version information.
+ *
+ * @stable
+ */
+export const version: Command<undefined, void> = () => {
+  tryReadVersion(['../../package.json', '../../../package.json']);
 
-    console.log(`ng-packagr:            ` + NG_PACKAGR_VERSION);
-    console.log(`@angular/compiler:     ` + COMPILER_VERSION.full);
-    console.log(`@angular/compiler-cli: ` + COMPILER_CLI_VERSION.full);
-    console.log(`rollup:                ` + ROLLUP_VERSION);
-    console.log(`tsickle:               ` + TSICKLE_VERSION);
-    console.log(`typescript:            ` + TS_VERSION);
-  };
+  console.log(`ng-packagr:            ` + NG_PACKAGR_VERSION);
+  console.log(`@angular/compiler:     ` + COMPILER_VERSION.full);
+  console.log(`@angular/compiler-cli: ` + COMPILER_CLI_VERSION.full);
+  console.log(`rollup:                ` + ROLLUP_VERSION);
+  console.log(`tsickle:               ` + TSICKLE_VERSION);
+  console.log(`typescript:            ` + TS_VERSION);
+};

--- a/src/lib/deprecations.ts
+++ b/src/lib/deprecations.ts
@@ -5,24 +5,28 @@ import { build, CliArguments } from './commands/build.command';
 import { execute } from './commands/command';
 import * as log from './util/log';
 
+/** @deprecated */
 export async function createNgPackage(opts: CliArguments): Promise<void> {
-  log.warn(`DEPRECATED: createNgPackage() is becoming deprecated. Invoke the 'build: Command' instead.`);
+  log.warn(
+    `DEPRECATED: createNgPackage() is deprecated and will be removed in v3. Invoke the Command 'build()' instead.`
+  );
   return execute(build, opts);
 }
 
 /**
- * XX: to be renamed to `BuildTask`, `BuildStep`, `Task`, ... ??!??
+ * `BuildStep` is deprecated.
+ * See the architectural re-write for a [transformation pipeline](./docs/transformation-pipeline.md).
  *
- * Call signature for a build step.
- *
- * @experimental Might change in the future!
+ * @deprecated Will be removed in v3.
  */
 export interface BuildStep {
+  (
+    {
 
-  ({}: {
-    artefacts: NgArtefacts,
-    entryPoint: NgEntryPoint,
-    pkg: NgPackage
-  }): void | any | Promise<void | any>;
-
+    }: {
+      artefacts: NgArtefacts;
+      entryPoint: NgEntryPoint;
+      pkg: NgPackage;
+    }
+  ): void | any | Promise<void | any>;
 }

--- a/src/lib/ts/ng-component-transformer.spec.ts
+++ b/src/lib/ts/ng-component-transformer.spec.ts
@@ -2,13 +2,14 @@ import { tags } from '@angular-devkit/core';
 import { expect } from 'chai';
 import * as ts from 'typescript';
 import { transformComponentSourceFiles } from './ng-component-transformer';
-import { createSourceFile } from '../../testing/typescript.testing';
+import { createSourceFile, createSourceText } from '../../testing/typescript.testing';
 
 describe(`transformComponentSourceFiles()`, () => {
   let FOO_SOURCE_FILE: ts.SourceFile;
 
   beforeEach(() => {
-    FOO_SOURCE_FILE = createSourceFile`
+    FOO_SOURCE_FILE = createSourceFile(
+      createSourceText`
       import { Component } from '@angular/core';
 
       @Component({
@@ -20,7 +21,9 @@ describe(`transformComponentSourceFiles()`, () => {
         styles: ['not-of-interest', 'also-not']
       })
       export class FooComponent {}
-      `;
+      `,
+      '/foo-bar/foo.ts'
+    );
   });
 
   it(`must not alter the AST when TemplateTransformer/StylesheetTransformer return void`, () => {
@@ -57,7 +60,7 @@ describe(`transformComponentSourceFiles()`, () => {
     expect(fooSourceTransformed[0]).to.not.equal(FOO_SOURCE_FILE);
   });
 
-  it(`should apply string replacements to source text`, () => {
+  it(`should apply string replacements to source text when transformers return string values`, () => {
     const templateReplacer = 'templateFoo';
     const styleReplacer = 'styleBar';
     const transformer = transformComponentSourceFiles({
@@ -88,5 +91,84 @@ describe(`transformComponentSourceFiles()`, () => {
       })
       export class FooComponent {}
       `);
+  });
+
+  describe(`stylesheet: StylesheetTransformer`, () => {
+    it(`should call the transformer for each value in the styleUrls array`, () => {
+      let stylesheetsFound: string[] = [];
+      const transformer = transformComponentSourceFiles({
+        template: () => {},
+        stylesheet: ({ stylePath }) => {
+          stylesheetsFound.push(stylePath);
+        }
+      });
+
+      ts.transform(FOO_SOURCE_FILE, [transformer]);
+
+      expect(stylesheetsFound)
+        .to.be.an('array')
+        .that.has.length(3);
+      expect(stylesheetsFound)
+        .to.contain('./foo.component.css')
+        .and.to.contain('./more.css')
+        .and.to.contain('./even-more.ext');
+    });
+
+    it(`should resolve file path of the stylesheet file relative to source file`, () => {
+      let stylesheets: any[] = [];
+      const transformer = transformComponentSourceFiles({
+        template: () => {},
+        stylesheet: args => {
+          stylesheets.push(args);
+        }
+      });
+
+      ts.transform(FOO_SOURCE_FILE, [transformer]);
+
+      expect(stylesheets)
+        .to.be.an('array')
+        .that.has.length(3);
+      expect(stylesheets[0]).to.have.property('stylePath', './foo.component.css');
+      expect(stylesheets[0]).to.have.property('styleFilePath', '/foo-bar/foo.component.css');
+      expect(stylesheets[0]).to.have.property('sourceFilePath', '/foo-bar/foo.ts');
+    });
+  });
+
+  describe(`template: TemplateTransformer`, () => {
+    it(`should call the transformer for the value found in templateUrl`, () => {
+      let templatesFound: string[] = [];
+      const transformer = transformComponentSourceFiles({
+        template: ({ templatePath }) => {
+          templatesFound.push(templatePath);
+        },
+        stylesheet: () => {}
+      });
+
+      ts.transform(FOO_SOURCE_FILE, [transformer]);
+
+      expect(templatesFound)
+        .to.be.an('array')
+        .that.has.length(1);
+      expect(templatesFound).to.contain('./foo.component.html');
+    });
+
+    it(`should resolve file path of the template file relative to source file`, () => {
+      let templates: any[] = [];
+      const transformer = transformComponentSourceFiles({
+        template: args => {
+          templates.push(args);
+        },
+        stylesheet: () => {}
+      });
+
+      ts.transform(FOO_SOURCE_FILE, [transformer]);
+
+      expect(templates)
+        .to.be.an('array')
+        .that.has.length(1);
+      expect(templates[0]).to.have.property('templatePath', './foo.component.html');
+      expect(templates[0]).to.have.property('templateFilePath', '/foo-bar/foo.component.html');
+      expect(templates[0]).to.have.property('sourceFilePath', '/foo-bar/foo.ts');
+    });
   });
 });

--- a/src/lib/ts/ng-component-transformer.ts
+++ b/src/lib/ts/ng-component-transformer.ts
@@ -44,7 +44,7 @@ export interface StylesheetTransformer {
   ): string | undefined | void;
 }
 
-export interface ComponentTransformer {
+export interface ComponentSourceFileTransformer {
   (
     {
 
@@ -55,7 +55,7 @@ export interface ComponentTransformer {
   ): ts.TransformerFactory<ts.SourceFile>;
 }
 
-export const transformComponentSourceFiles: ComponentTransformer = ({ template, stylesheet }) =>
+export const transformComponentSourceFiles: ComponentSourceFileTransformer = ({ template, stylesheet }) =>
   transformComponent({
     templateUrl: node => {
       const sourceFile = node.getSourceFile();

--- a/src/lib/ts/transform-component.ts
+++ b/src/lib/ts/transform-component.ts
@@ -15,9 +15,9 @@ export type ComponentTransformer = {
   file?: ts.Transformer<ts.SourceFile>;
 };
 
-export const transformComponent = (transformer: ComponentTransformer) => (context: ts.TransformationContext) => (
-  sourceFile: ts.SourceFile
-): ts.SourceFile => {
+export const transformComponent: (
+  transformer: ComponentTransformer
+) => ts.TransformerFactory<ts.SourceFile> = transformer => context => sourceFile => {
   // skip source files from 'node_modules' directory (third-party source)
   if (sourceFile.fileName.includes('node_modules')) {
     return sourceFile;
@@ -39,7 +39,7 @@ export const transformComponent = (transformer: ComponentTransformer) => (contex
       : ts.visitEachChild(node, visitDecorators, context);
 
   // Either custom file transformer or identity transform
-  const transformFile = transformer.file ? transformer.file : file => file;
+  const transformFile: ts.Transformer<ts.SourceFile> = transformer.file ? transformer.file : file => file;
 
   return transformFile(ts.visitNode(sourceFile, visitDecorators));
 };

--- a/src/public_api.spec.ts
+++ b/src/public_api.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+// Public API imports the way of user's: 'import {..} from 'ng-packagr'';
+import { ngPackagr, NgPackagr, build, version, execute, Command } from './public_api';
+
+describe("Public API Surface: import {..} from 'ng-packagr';", () => {
+  describe('NgPackagr', () => {
+    it('should export `ngPackagr()` fluent API', () => {
+      expect(ngPackagr).to.be.a('function');
+      expect(ngPackagr()).to.be.and.instanceof(NgPackagr);
+    });
+  });
+
+  describe('Command API', () => {
+    it('should export the `build` command', () => {
+      expect(build).to.be.a('function');
+    });
+
+    it('should export the `version` command', () => {
+      expect(version).to.be.a('function');
+    });
+
+    it(`should export the command runner 'execute'`, () => {
+      expect(execute).to.be.a('function');
+    });
+  });
+});

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -1,5 +1,30 @@
+/**
+ * Commands API
+ */
 export * from './lib/commands/command';
 export * from './lib/commands/build.command';
 export * from './lib/commands/version.command';
+
+/**
+ * ngPackagr() programmatic API
+ */
 export * from './lib/ng-v5/packagr';
+
+/**
+ * Angular-specifics for tsc and ngc
+ */
+export { compileSourceFiles } from './lib/ngc/compile-source-files';
+export { transformSourceFiles } from './lib/ngc/transform-source-files';
+export {
+  TemplateTransformer,
+  StylesheetTransformer,
+  ComponentSourceFileTransformer,
+  transformComponentSourceFiles
+} from './lib/ts/ng-component-transformer';
+export { isComponentDecorator, isStyleUrls, isTemplateUrl } from './lib/ts/ng-type-guards';
+export { ComponentTransformer, transformComponent } from './lib/ts/transform-component';
+
+/**
+ * Deprecations that are going to be removed in v3.
+ */
 export * from './lib/deprecations';

--- a/src/testing/typescript.testing.ts
+++ b/src/testing/typescript.testing.ts
@@ -1,6 +1,17 @@
 import { tags } from '@angular-devkit/core';
 import * as ts from 'typescript';
 
-export function createSourceFile(sourceText: TemplateStringsArray, fileName: string = 'foo.ts'): ts.SourceFile {
-  return ts.createSourceFile(fileName, tags.stripIndent(sourceText), ts.ScriptTarget.ES5, true, ts.ScriptKind.TS);
+export function createSourceFile(
+  sourceText: TemplateStringsArray | string,
+  fileName: string = 'foo.ts'
+): ts.SourceFile {
+  if (typeof sourceText !== 'string') {
+    sourceText = tags.stripIndent(sourceText);
+  }
+
+  return ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.ES5, true, ts.ScriptKind.TS);
+}
+
+export function createSourceText(sourceText: TemplateStringsArray) {
+  return tags.stripIndent(sourceText);
 }

--- a/src/testing/typesript.testing.spec.ts
+++ b/src/testing/typesript.testing.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as ts from 'typescript';
 import { createSourceFile } from './typescript.testing';
 
-describe(`testing: typescript`, () => {
+describe(`Testing: typescript utilities`, () => {
   describe(`createSourceFile()`, () => {
     let sourceFile: ts.SourceFile;
     beforeEach(() => {


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Arrange the public API surface for programmatic usage.

```ts
import { ngPackagr, /* .. */ } from 'ng-packagr';
```

See the `public_api.ts` for the list of exported symbols.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
