### PR TITLE
fix: recognize aliased and namespace decorator imports

### DIFF
--- a/src/lib/ts/ng-type-guards.spec.ts
+++ b/src/lib/ts/ng-type-guards.spec.ts
@@ -1,25 +1,94 @@
 import { expect } from 'chai';
 import * as ts from 'typescript';
 import { createSourceFile } from '../../testing/typescript.testing';
-import { isComponentDecorator, isTemplateUrl, isStyleUrls } from './ng-type-guards';
+import {
+  isComponentDecorator,
+  isTemplateUrl,
+  isStyleUrls,
+  resolveImportSymbolsFromModule,
+  isImportFromModule
+} from './ng-type-guards';
 
 describe(`ng-type-guards`, () => {
-  const sourceFileOne = createSourceFile`
-    import {Component} from '@angular/core';
+  describe(`isComponentDecorator()`, () => {
+    const sourceFileNamedImport = createSourceFile`
+      import { Component } from '@angular/core';
 
-    @Component({})
-    @Other
-    class MyComponent {}
-  `;
+      @Component({})
+      @Other
+      class MyComponent {}
+    `;
 
-  const sourceFileTwo = createSourceFile`
+    it(`should return false for other decorator`, () => {
+      const otherDecorator = sourceFileNamedImport
+        .getChildAt(0)
+        .getChildAt(1)
+        .getChildAt(0)
+        .getChildAt(1);
+      expect(isComponentDecorator(otherDecorator)).to.be.false;
+    });
+
+    it(`should return false for non 'SyntaxKind.Decorator' nodes`, () => {
+      const nonDecoratorNode = sourceFileNamedImport.getChildAt(0);
+      expect(isComponentDecorator(nonDecoratorNode)).to.be.false;
+    });
+
+    it("should return true for `import { Component } from '@angular/core'`", () => {
+      const decoratorNode = sourceFileNamedImport
+        .getChildAt(0)
+        .getChildAt(1)
+        .getChildAt(0)
+        .getChildAt(0);
+      expect(isComponentDecorator(decoratorNode)).to.be.true;
+    });
+
+    it("should return true for `import { Component as Foo } from '@angular/core'`", () => {
+      const sourceFile = createSourceFile`
+        import { Component as Foo } from '@angular/core';
+
+        @Foo({
+          selector: 'foo',
+          template: '<h1>Hey yo, I am from an aliased, named import</h1>'
+        })
+        export class FooComponent {}
+      `;
+      const decoratorNode = sourceFile
+        .getChildAt(0)
+        .getChildAt(1)
+        .getChildAt(0)
+        .getChildAt(0);
+
+      expect(isComponentDecorator(decoratorNode)).to.be.true;
+    });
+
+    it("should return true for `import * as ngCore from '@angular/core'`", () => {
+      const sourceFile = createSourceFile`
+        import * as ngCore from '@angular/core';
+
+        @ngCore.Component({
+          selector: 'foo',
+          template: '<h1>Hey yo, I am from a namespace import</h1>'
+        })
+        export class FooComponent {}
+      `;
+      const decoratorNode = sourceFile
+        .getChildAt(0)
+        .getChildAt(1)
+        .getChildAt(0)
+        .getChildAt(0);
+
+      expect(isComponentDecorator(decoratorNode)).to.be.true;
+    });
+  });
+
+  const sourceFileComponentTemplateUrlAndStyleUrl = createSourceFile`
     @Component({
       templateUrl: './my.component.html',
       styleUrls: ['./my.component.css']
     })
     class MyComponent {}
   `;
-  const sourceTwo_syntaxList = sourceFileTwo
+  const sourceTwo_syntaxList = sourceFileComponentTemplateUrlAndStyleUrl
     .getChildAt(0)
     .getChildAt(0)
     .getChildAt(0)
@@ -31,32 +100,7 @@ describe(`ng-type-guards`, () => {
   const sourceTwo_templateUrlNode = sourceTwo_syntaxList.getChildAt(0);
   const sourceTwo_styleUrlsNode = sourceTwo_syntaxList.getChildAt(2);
 
-  describe(`isComponentDecorator`, () => {
-    it(`should return true for '@Component()'`, () => {
-      const decoratorNode = sourceFileOne
-        .getChildAt(0)
-        .getChildAt(1)
-        .getChildAt(0)
-        .getChildAt(0);
-      expect(isComponentDecorator(decoratorNode)).to.be.true;
-    });
-
-    it(`should return false for other decorator`, () => {
-      const otherDecorator = sourceFileOne
-        .getChildAt(0)
-        .getChildAt(1)
-        .getChildAt(0)
-        .getChildAt(1);
-      expect(isComponentDecorator(otherDecorator)).to.be.false;
-    });
-
-    it(`should return false for non 'SyntaxKind.Decorator' nodes`, () => {
-      const nonDecoratorNode = sourceFileOne.getChildAt(0);
-      expect(isComponentDecorator(nonDecoratorNode)).to.be.false;
-    });
-  });
-
-  describe(`isTemplateUrl`, () => {
+  describe(`isTemplateUrl()`, () => {
     it(`it should return 'true' for 'templateUrl:'`, () => {
       expect(isTemplateUrl(sourceTwo_templateUrlNode)).to.be.true;
     });
@@ -66,12 +110,12 @@ describe(`ng-type-guards`, () => {
     });
 
     it(`it should return 'false' for other nodes`, () => {
-      expect(isTemplateUrl(sourceFileTwo)).to.be.false;
+      expect(isTemplateUrl(sourceFileComponentTemplateUrlAndStyleUrl)).to.be.false;
       expect(isTemplateUrl(sourceTwo_syntaxList)).to.be.false;
     });
   });
 
-  describe(`isStyleUrls`, () => {
+  describe(`isStyleUrls()`, () => {
     it(`it should return 'true' for 'stylesUrls:'`, () => {
       expect(isStyleUrls(sourceTwo_styleUrlsNode)).to.be.true;
     });
@@ -81,8 +125,75 @@ describe(`ng-type-guards`, () => {
     });
 
     it(`it should return 'false' for other nodes`, () => {
-      expect(isStyleUrls(sourceFileTwo)).to.be.false;
+      expect(isStyleUrls(sourceFileComponentTemplateUrlAndStyleUrl)).to.be.false;
       expect(isStyleUrls(sourceTwo_syntaxList)).to.be.false;
+    });
+  });
+
+  describe(`isImportFromModule()`, () => {
+    const IMPORTS = createSourceFile`
+      import { Component as FooBar } from '@angular/core';
+      import { Component } from '@angular/core';
+      import * as ng from '@angular/core';
+      `;
+    const ALIAS_IMPORT = IMPORTS.getChildAt(0).getChildAt(0);
+    const NAMED_IMPORT = IMPORTS.getChildAt(0).getChildAt(0);
+    const NAMESPACED_IMPORT = IMPORTS.getChildAt(0).getChildAt(0);
+
+    it(`should return true when module identifier is equivalent`, () => {
+      expect(isImportFromModule(ALIAS_IMPORT, '@angular/core')).to.be.true;
+      expect(isImportFromModule(NAMED_IMPORT, '@angular/core')).to.be.true;
+      expect(isImportFromModule(NAMESPACED_IMPORT, '@angular/core')).to.be.true;
+    });
+
+    it(`should return false when module identifier is in-equal`, () => {
+      expect(isImportFromModule(ALIAS_IMPORT, 'foo-bar')).to.be.false;
+      expect(isImportFromModule(NAMED_IMPORT, 'foo-bar')).to.be.false;
+      expect(isImportFromModule(NAMESPACED_IMPORT, 'foo-bar')).to.be.false;
+    });
+
+    it(`should return false for non-import declaration nodes`, () => {
+      expect(isImportFromModule(IMPORTS, 'foo')).to.be.false;
+    });
+  });
+
+  describe(`resolveImportSymbolsFromModule()`, () => {
+    const IMPORTS = createSourceFile`
+      import { Component as FooBar } from '@angular/core';
+      import { Directive } from '@angular/core';
+      import * as ngCore from '@angular/core';
+      import foo from 'foo-bar';
+
+      export class FooBar {}
+      `;
+    const FOO_BAR_CLASS_NODE = IMPORTS.getChildAt(0).getChildAt(4);
+
+    it("should resolve a namespace `import * as foo` to '__namespace' property with value 'foo'", () => {
+      const imports = resolveImportSymbolsFromModule(FOO_BAR_CLASS_NODE, '@angular/core');
+      expect(imports.__namespace).to.equal('ngCore');
+    });
+
+    it('should resolve an aliased import: `import { Foo as Bar }`', () => {
+      const imports = resolveImportSymbolsFromModule(FOO_BAR_CLASS_NODE, '@angular/core');
+      expect(imports['Component']).to.equal('FooBar');
+    });
+
+    it('should resolve a named import: `import { Foo }`', () => {
+      const imports = resolveImportSymbolsFromModule(FOO_BAR_CLASS_NODE, '@angular/core');
+      expect(imports['Directive']).to.equal('Directive');
+    });
+
+    it(`must not resolve import symbols from other symbols`, () => {
+      const imports = resolveImportSymbolsFromModule(FOO_BAR_CLASS_NODE, '@angular/core');
+      expect(imports['foo']).to.be.undefined;
+    });
+
+    it(`must not contain import symbols from non-imported-modules`, () => {
+      const imports = resolveImportSymbolsFromModule(FOO_BAR_CLASS_NODE, 'non-imported-module');
+      expect(imports.__namespace).to.be.undefined;
+      expect(Object.keys(imports))
+        .to.be.an('array')
+        .that.has.length(0);
     });
   });
 });

--- a/src/lib/ts/ng-type-guards.ts
+++ b/src/lib/ts/ng-type-guards.ts
@@ -3,15 +3,27 @@ import * as ts from 'typescript';
 export const isComponentDecorator = (node: ts.Node): node is ts.Decorator => {
   if (ts.isDecorator(node)) {
     const callExpression = node.getChildren().find(ts.isCallExpression);
-    if (callExpression) {
-      const identifier = callExpression.getChildren().find(ts.isIdentifier);
+    // callExpression may be undefined, check
+    if (callExpression && ts.isCallExpression(callExpression)) {
+      const decoratorExpression = callExpression.expression;
 
-      return identifier && identifier.getText() === 'Component';
-      /* TODO: text comparison can break when
-        * `import { Component as foo } from '@angular/core'` or
-        * `import * as ng from '@angular/core'`
-        * @link https://github.com/angular/devkit/blob/master/packages/schematics/angular/utility/ast-utils.ts#L127-L128
-        */
+      if (ts.isIdentifier(decoratorExpression)) {
+        // Accounts for `import { Component } from '@angular/core`
+        // and accounts for `import { Component as Foo } from '@angular/core';`
+        const identifierText = decoratorExpression.getText();
+        const ngCoreImports = resolveImportSymbolsFromModule(node, '@angular/core');
+
+        return ngCoreImports['Component'] === identifierText;
+      } else if (ts.isPropertyAccessExpression(decoratorExpression)) {
+        // Accounts for `import * as ng from '@angular/core'`;
+        const namespaceName = decoratorExpression.expression.getText();
+        const namespacePropertyName = decoratorExpression.name.getText();
+        const ngCoreImports = resolveImportSymbolsFromModule(node, '@angular/core');
+
+        return namespacePropertyName === 'Component' && namespaceName === ngCoreImports.__namespace;
+      }
+
+      return false;
     }
   }
 
@@ -25,3 +37,45 @@ export const isTemplateUrl = (node: ts.Node): node is ts.PropertyAssignment =>
   isPropertyAssignmentFor(node, 'templateUrl');
 
 export const isStyleUrls = (node: ts.Node): node is ts.PropertyAssignment => isPropertyAssignmentFor(node, 'styleUrls');
+
+export const isImportFromModule = (node: ts.Node, moduleIdentifier: string): node is ts.ImportDeclaration => {
+  if (ts.isImportDeclaration(node)) {
+    const moduleSpecififer = node.moduleSpecifier.getText();
+    const moduleId = moduleSpecififer.substring(1, moduleSpecififer.length - 1);
+
+    return moduleId === moduleIdentifier;
+  }
+
+  return false;
+};
+
+export const resolveImportSymbolsFromModule = (node: ts.Node, moduleIdentifier: string) => {
+  const importSymbols: {
+    __namespace?: string;
+    [key: string]: string;
+  } = {};
+
+  return node
+    .getSourceFile()
+    .statements.filter(statement => isImportFromModule(statement, moduleIdentifier))
+    .map((importDeclaration: ts.ImportDeclaration) => importDeclaration.importClause)
+    .reduce((symbols, importClause) => {
+      const importNode = importClause.getChildAt(0);
+      if (ts.isNamedImports(importNode)) {
+        const importSpecifier = importNode.elements;
+
+        for (let specifier of importSpecifier) {
+          // Accounts for aliased imports and straight named imports
+          const importedFrom = specifier.propertyName ? specifier.propertyName.getText() : specifier.name.getText();
+          const importedAs = specifier.name.getText();
+
+          importSymbols[importedFrom] = importedAs;
+        }
+      } else if (ts.isNamespaceImport(importNode)) {
+        const importedAsNamespace = importNode.name.getText();
+        importSymbols.__namespace = importedAsNamespace;
+      }
+
+      return importSymbols;
+    }, importSymbols);
+};


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Recognize component decorator metadata for named, aliased imports and namespace imports.

Usage Examples:

```ts
import { Component as Foo } from '@angular/core';

@Foo({
  selector: 'foo',
  template: `<h1>He yo, I am from a named, aliased import</h1>`
})
export class FooComponent {}
```

```ts
import * as ngCore from '@angular/core';

@ngCore.Component({
  selector: 'foo',
  template: `<h1>He yo, I am from a namespace import</h1>`
})
export class FooComponent {}
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
