### PR TITLE
fix: multiple import statements for `tslib`

### DIFF
--- a/integration/samples/core/specs/es5-api.ts
+++ b/integration/samples/core/specs/es5-api.ts
@@ -36,7 +36,7 @@ describe(`@sample/core`, () => {
     });
 
     it(`should import TS helpers from 'tslib'`, () => {
-      expect(BUNDLE).to.contain(`from "tslib"`);
+      expect(BUNDLE).to.contain(`import { __spread } from 'tslib'`);
     });
 
     it(`should downlevel iteration`, () => {

--- a/src/lib/flatten/flatten.ts
+++ b/src/lib/flatten/flatten.ts
@@ -58,7 +58,14 @@ export async function flattenToFesm15(opts: FlattenOpts): Promise<string> {
 export async function flattenToFesm5(opts: FlattenOpts): Promise<string> {
   const destFile = path.resolve(opts.outDir, 'esm5', opts.flatModuleFile + '.js');
 
-  await downlevelWithTsc(opts.entryFile, destFile);
+  await rollupBundleFile({
+    moduleName: opts.esmModuleId,
+    entry: opts.entryFile,
+    format: 'es',
+    dest: destFile,
+    embedded: opts.embedded,
+    transform: downlevelWithTsc
+  });
 
   return destFile;
 }

--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as log from '../util/log';
 import { externalModuleIdStrategy } from './external-module-id-strategy';
 import { umdModuleIdStrategy } from './umd-module-id-strategy';
+import { TransformHook } from 'rollup';
 
 /**
  * Options used in `ng-packagr` for writing flat bundle files.
@@ -22,6 +23,7 @@ export interface RollupOptions {
   embedded?: string[];
   comments?: string;
   licensePath?: string;
+  transform?: TransformHook;
 }
 
 /** Runs rollup over the given entry file, writes a bundle file. */
@@ -33,7 +35,8 @@ export async function rollupBundleFile(opts: RollupOptions): Promise<void> {
     commonJs(),
     cleanup({
       comments: opts.comments
-    })
+    }),
+    { transform: opts.transform }
   ];
 
   if (opts.licensePath) {


### PR DESCRIPTION
Closes: #587

## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Cherry pick tslib methods and avoid having multiple imports for tslib


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
