### PR TITLE
feat: `styleIncludePaths` for feature parity with Angular CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 [![npm Downloads](https://img.shields.io/npm/dw/ng-packagr.svg?style=flat-square)](https://www.npmjs.com/package/ng-packagr)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?style=flat-square)](https://renovateapp.com/)
 
-
 ## Usage Example
 
 Let's talk us through a _getting started_ that'll build an Angular library from TypeScript sources and create a distribution-ready npm package:
@@ -62,24 +61,22 @@ Do you like to publish more libraries?
 Is your code living in a monorepo?
 Create one `package.json` per npm package, run _ng-packagr_ for each!
 
-
 ## Features
 
- - :gift: Implements [Angular Package Format](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview)
-   - :checkered_flag: Bundles your library in FESM2015, FESM5, and UMD formats
-   - :school_satchel: npm package can be consumed by [Angular CLI](https://github.com/angular/angular-cli), [Webpack](https://github.com/webpack/webpack), or [SystemJS](https://github.com/systemjs/systemjs)
-   - :dancer: Creates type definitions (`.d.ts`)
-   - :runner: Generates [Ahead-of-Time](https://angular.io/guide/aot-compiler#why-do-aot-compilation) metadata (`.metadata.json`)
-   - :trophy: Auto-discovers and bundles secondary entry points such as `@my/foo`, `@my/foo/testing`, `@my/foo/bar`
- - :mag_right: Creates [scoped and non-scoped packages](https://docs.npmjs.com/misc/scope) for publishing to npm registry
- - :surfer: Inlines Templates and Stylesheets
- - :sparkles: CSS Features
-   - :camel: Runs [SCSS](http://sass-lang.com/guide) preprocessor, supporting the [relative `~` import syntax](https://github.com/webpack-contrib/sass-loader#imports) and custom include paths
-   - :elephant: Runs [less](http://lesscss.org/#getting-started) preprocessor
-   - :snake: Runs [Stylus](http://stylus-lang.com) preprocessor, resolves relative paths relative to ng-package.json
-   - :monkey: Adds vendor-specific prefixes w/ [autoprefixer](https://github.com/postcss/autoprefixer#autoprefixer-) and [browserslist](https://github.com/ai/browserslist#queries) &mdash; just tell your desired `.browserslistrc`
-   - :tiger: Embed assets data w/ [postcss-url](https://github.com/postcss/postcss-url#inline)
-
+* :gift: Implements [Angular Package Format](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview)
+  * :checkered_flag: Bundles your library in FESM2015, FESM5, and UMD formats
+  * :school_satchel: npm package can be consumed by [Angular CLI](https://github.com/angular/angular-cli), [Webpack](https://github.com/webpack/webpack), or [SystemJS](https://github.com/systemjs/systemjs)
+  * :dancer: Creates type definitions (`.d.ts`)
+  * :runner: Generates [Ahead-of-Time](https://angular.io/guide/aot-compiler#why-do-aot-compilation) metadata (`.metadata.json`)
+  * :trophy: Auto-discovers and bundles secondary entry points such as `@my/foo`, `@my/foo/testing`, `@my/foo/bar`
+* :mag_right: Creates [scoped and non-scoped packages](https://docs.npmjs.com/misc/scope) for publishing to npm registry
+* :surfer: Inlines Templates and Stylesheets
+* :sparkles: CSS Features
+  * :camel: Runs [SCSS](http://sass-lang.com/guide) preprocessor, supporting the [relative `~` import syntax](https://github.com/webpack-contrib/sass-loader#imports) and custom include paths
+  * :elephant: Runs [less](http://lesscss.org/#getting-started) preprocessor
+  * :snake: Runs [Stylus](http://stylus-lang.com) preprocessor, resolves relative paths relative to ng-package.json
+  * :monkey: Adds vendor-specific prefixes w/ [autoprefixer](https://github.com/postcss/autoprefixer#autoprefixer-) and [browserslist](https://github.com/ai/browserslist#queries) &mdash; just tell your desired `.browserslistrc`
+  * :tiger: Embed assets data w/ [postcss-url](https://github.com/postcss/postcss-url#inline)
 
 ## Advanced Use Cases
 
@@ -93,11 +90,10 @@ Here is a [demo repository showing ng-packagr and Angular CLI](https://github.co
 
 What about [ng-packagr alongside Nx Workspace](https://github.com/dherges/nx-packaged)? Well, they work well together!
 
-
 #### Configuration Locations
 
 Configuration is picked up from the project file given by the `-p` CLI option.
-The `-p `option may refer to a `package.json` (with custom `ngPackage` property), an `ng-package.json`, or an `ng-package.js` file.
+The `-p`option may refer to a `package.json` (with custom `ngPackage` property), an `ng-package.json`, or an `ng-package.js` file.
 When the `-p` option refers to a directory, the configuration is picked up from the first matching source;
 locations are tried in the above-mentioned order.
 
@@ -168,6 +164,7 @@ my_package
 ```
 
 The contents of `my_package/testing/package.json` can be as simple as:
+
 ```json
 {
   "ngPackage": {}
@@ -202,7 +199,7 @@ For example:
 {
   "ngPackage": {
     "lib": {
-      "languageLevel": [ "dom", "es2017" ]
+      "languageLevel": ["dom", "es2017"]
     }
   }
 }
@@ -225,16 +222,16 @@ Valid values: `none` or `inline`.
 }
 ```
 
-#### What if I have multiple SASS/SCSS include paths?
+#### What if I have multiple SASS/SCSS/Less/Stylus include paths?
 
 In case you have multiple include paths for `@import` statements (e.g., when setting the `stylePreprocessorOptions` in `.angular-cli.json`),
-the additional paths may be configured through the `sassIncludePaths` option.
+the additional paths may be configured through the `styleIncludePaths` option.
 
 ```json
 {
   "ngPackage": {
     "lib": {
-      "sassIncludePaths": ["./src/assets/styles"]
+      "styleIncludePaths": ["./src/assets/styles"]
     }
   }
 }
@@ -247,16 +244,13 @@ In most cases, you should expect that third-party dependencies will be part of t
 
 However, if you want to embed a dependency into the distributable bundle you are able to do so by adding the dependency in the `embedded` section like so:
 
-***HEADS UP***: embedding a dependency will result in you shipping the dependency's source code to your consumers!
+**_HEADS UP_**: embedding a dependency will result in you shipping the dependency's source code to your consumers!
 
 ```json
 {
   "$schema": "../../../src/ng-package.schema.json",
   "lib": {
-    "embedded": [
-      "lodash",
-      "date-fns"
-    ]
+    "embedded": ["lodash", "date-fns"]
   }
 }
 ```
@@ -271,8 +265,8 @@ In case ng-packagr doesn't provide a default and rollup is unable to guess the c
   "$schema": "../../../src/ng-package.schema.json",
   "lib": {
     "umdModuleIds": {
-      "lodash" : "_",
-      "date-fns" : "DateFns",
+      "lodash": "_",
+      "date-fns": "DateFns"
     }
   }
 }
@@ -340,17 +334,13 @@ The licensePath property in the example above will read the LICENSE file next to
 We keep track of user questions in GitHub's issue tracker and try to build a documentation from it.
 [Explore issues w/ label documentation](https://github.com/dherges/ng-packagr/issues?q=label%3Adocumentation%20).
 
-
-
 ## Knowledge
 
 [Angular Package Format v5.0](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview), design document at Google Docs
 
-
 Packaging Angular - Jason Aden at ng-conf 2017 ([28min talk](https://youtu.be/unICbsPGFIA))
 
 [![Packaging Angular - Jason Aden](https://img.youtube.com/vi/unICbsPGFIA/0.jpg)](https://youtu.be/unICbsPGFIA)
-
 
 Create and publish Angular libs like a Pro - Juri Strumpflohner at NG-BE ([Dec 2017, 30min talk](https://youtu.be/K4YMmwxGKjY))
 

--- a/integration/samples/scss-paths/assets/theme.less
+++ b/integration/samples/scss-paths/assets/theme.less
@@ -1,0 +1,1 @@
+@foreground-color-bright: 'red';

--- a/integration/samples/scss-paths/assets/theme.styl
+++ b/integration/samples/scss-paths/assets/theme.styl
@@ -1,0 +1,1 @@
+$font-size-large = 32pt

--- a/integration/samples/scss-paths/baz/baz.component.html
+++ b/integration/samples/scss-paths/baz/baz.component.html
@@ -1,1 +1,1 @@
-<h1 class="baz">baz!</h1>
+<h1 class="baz">baz<span class="oom">!</span></h1>

--- a/integration/samples/scss-paths/baz/baz.component.less
+++ b/integration/samples/scss-paths/baz/baz.component.less
@@ -1,0 +1,7 @@
+@import 'theme';
+
+.baz {
+  .oom {
+    color: @foreground-color-bright;
+  }
+}

--- a/integration/samples/scss-paths/baz/baz.component.styl
+++ b/integration/samples/scss-paths/baz/baz.component.styl
@@ -1,0 +1,4 @@
+@import "theme"
+
+.baz
+  font-size: $font-size-large

--- a/integration/samples/scss-paths/baz/baz.component.ts
+++ b/integration/samples/scss-paths/baz/baz.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'baz-component',
   templateUrl: './baz.component.html',
-  styleUrls: ['./baz.component.scss']
+  styleUrls: ['./baz.component.scss', './baz.component.less', './baz.component.styl']
 })
-export class BazComponent {
-}
+export class BazComponent {}

--- a/integration/samples/scss-paths/specs/metadata.ts
+++ b/integration/samples/scss-paths/specs/metadata.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 
 describe(`@sample/scss-paths`, () => {
-
   describe(`sample-scss-paths.metadata.json`, () => {
     let METADATA;
     before(() => {
@@ -16,10 +15,21 @@ describe(`@sample/scss-paths`, () => {
       expect(METADATA['importAs']).to.equal('@sample/scss-paths');
     });
 
-    it(`should resolve the styles from the theme`, () => {
-      const styles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(styles).to.contain(`color:"red"`);
-      expect(styles).to.contain(`background-color:"yellow"`);
+    it(`should resolve the styles from the SCSS theme`, () => {
+      const scssStyles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][0];
+      expect(scssStyles).to.contain(`color:"red"`);
+      expect(scssStyles).to.contain(`background-color:"yellow"`);
+    });
+
+    it(`should resolve the styles from the Less theme`, () => {
+      const lessStyles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][1];
+      expect(lessStyles).to.contain(`.baz .oom`);
+      expect(lessStyles).to.contain(`color:'red'`);
+    });
+
+    it(`should resolve the styles from the Stylus theme`, () => {
+      const stylusStyles = METADATA['metadata']['BazComponent']['decorators'][0]['arguments'][0]['styles'][2];
+      expect(stylusStyles).to.contain(`font-size:32pt`);
     });
   });
 
@@ -37,14 +47,34 @@ describe(`@sample/scss-paths`, () => {
       expect(METADATA['importAs']).to.equal('@sample/scss-paths/sub-module');
     });
 
-    it(`should resolve the styles from the parent theme`, () => {
-      const styles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(styles).to.contain(`background-color:"yellow"`);
+    it(`should resolve the SCSS styles from the parent theme`, () => {
+      const scssStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
+      expect(scssStyles).to.contain(`background-color:"yellow"`);
     });
 
-    it(`should resolve the styles from the sub-module common utilities`, () => {
-      const styles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
-      expect(styles).to.contain(`border:10px solid "yellow"`);
+    it(`should resolve the SCSS styles from the sub-module common utilities`, () => {
+      const scssStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][0];
+      expect(scssStyles).to.contain(`border:10px solid "yellow"`);
+    });
+
+    it(`should resolve the Less styles from the parent theme`, () => {
+      const lessStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][1];
+      expect(lessStyles).to.contain(`color:'red'`);
+    });
+
+    it(`should resolve the Less styles from the sub-module common utilities`, () => {
+      const lessStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][1];
+      expect(lessStyles).to.contain(`font-weight:bold`);
+    });
+
+    it(`should resolve the Stylus styles from the parent theme`, () => {
+      const stylusStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][2];
+      expect(stylusStyles).to.contain(`font-size:32pt`);
+    });
+
+    it(`should resolve the Stylus styles from the sub-module common utilities`, () => {
+      const stylusStyles = METADATA['metadata']['BarComponent']['decorators'][0]['arguments'][0]['styles'][2];
+      expect(stylusStyles).to.contain(`font-face:sans-serif`);
     });
   });
 });

--- a/integration/samples/scss-paths/sub-module/assets/common.less
+++ b/integration/samples/scss-paths/sub-module/assets/common.less
@@ -1,0 +1,4 @@
+.colored-font(@color, @weight) {
+  color: @color;
+  font-weight: @weight;
+}

--- a/integration/samples/scss-paths/sub-module/assets/common.styl
+++ b/integration/samples/scss-paths/sub-module/assets/common.styl
@@ -1,0 +1,3 @@
+font-sized(name, size)
+  font-face name
+  font-size size

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.less
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.less
@@ -1,0 +1,6 @@
+@import 'theme';
+@import 'common';
+
+.foo {
+  .colored-font(@foreground-color-bright, bold);
+}

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.styl
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.styl
@@ -1,0 +1,5 @@
+@import "theme"
+@require "common"
+
+.foo
+  font-sized(sans-serif, $font-size-large)

--- a/integration/samples/scss-paths/sub-module/bar/bar.component.ts
+++ b/integration/samples/scss-paths/sub-module/bar/bar.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'bar-component',
   templateUrl: './bar.component.html',
-  styleUrls: ['./bar.component.scss']
+  styleUrls: ['./bar.component.scss', './bar.component.less', './bar.component.styl']
 })
-export class BarComponent {
-}
+export class BarComponent {}

--- a/integration/samples/scss-paths/sub-module/package.json
+++ b/integration/samples/scss-paths/sub-module/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../../src/package.schema.json",
-  "name": "@sample/secondary/sub-module",
+  "name": "@sample/scss-paths/sub-module",
   "description": "A sub module library",
   "version": "1.0.0-pre.0",
   "private": true,
@@ -12,7 +12,7 @@
   "ngPackage": {
     "lib": {
       "entryFile": "index.ts",
-      "sassIncludePaths": ["../assets","./assets"]
+      "sassIncludePaths": ["../assets", "./assets"]
     }
   }
 }

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -95,8 +95,9 @@ export class NgEntryPoint {
     return this.$get('lib.flatModuleFile') || this.flattenModuleId('-');
   }
 
-  public get sassIncludePaths(): string[] {
-    const includePaths = this.$get('lib.sassIncludePaths') || [];
+  public get styleIncludePaths(): string[] {
+    // lib.sassIncludePaths retained for backwards compatability
+    const includePaths = this.$get('lib.styleIncludePaths') || this.$get('lib.sassIncludePaths') || [];
     return includePaths.map(
       includePath => (path.isAbsolute(includePath) ? includePath : path.resolve(this.basePath, includePath))
     );

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -9,12 +9,14 @@
       "type": "string"
     },
     "dest": {
-      "description": "Destination folder where distributable binaries of the Angular library are written (default: `dist`).",
+      "description":
+        "Destination folder where distributable binaries of the Angular library are written (default: `dist`).",
       "type": "string",
       "default": "dist"
     },
     "workingDirectory": {
-      "description": "Internal working directory of ng-packagr where intermediate build files are stored (default: `.ng_pkg_build`).",
+      "description":
+        "Internal working directory of ng-packagr where intermediate build files are stored (default: `.ng_pkg_build`).",
       "type": "string",
       "default": ".ng_pkg_build"
     },
@@ -28,7 +30,8 @@
           "default": "src/public_api.ts"
         },
         "flatModuleFile": {
-          "description": "Filename of the auto-generated flat module file (if empty, defaults to the package name as given in `package.json`).",
+          "description":
+            "Filename of the auto-generated flat module file (if empty, defaults to the package name as given in `package.json`).",
           "type": "string",
           "default": ""
         },
@@ -40,7 +43,8 @@
           }
         },
         "umdModuleIds": {
-          "description": "A map of external dependencies and their correspondent UMD module identifiers. Map keys are TypeScript / EcmaScript module identifiers. Map values are UMD module ids. The purpose of this map is to correctly bundle an UMD module file (with `rollup`). By default, `rxjs`, `tslib` and `@angular/*` dependency symbols are supported.",
+          "description":
+            "A map of external dependencies and their correspondent UMD module identifiers. Map keys are TypeScript / EcmaScript module identifiers. Map values are UMD module ids. The purpose of this map is to correctly bundle an UMD module file (with `rollup`). By default, `rxjs`, `tslib` and `@angular/*` dependency symbols are supported.",
           "type": "object",
           "additionalProperties": true
         },
@@ -50,47 +54,45 @@
           "default": "all"
         },
         "licensePath": {
-          "description": "Licesnse file path to repend to the bundles",
+          "description": "Licesnse file path to prepend to the bundles",
           "type": "string",
           "default": ""
         },
         "jsx": {
-          "description": "A property to indicate whether your library is going to be bundling jsx/tsx files. This passes through to tsconfig - see https://www.typescriptlang.org/docs/handbook/jsx.html",
+          "description":
+            "A property to indicate whether your library is going to be bundling jsx/tsx files. This passes through to tsconfig - see https://www.typescriptlang.org/docs/handbook/jsx.html",
           "type": "string",
-          "enum": [
-            "preserve",
-            "react",
-            "react-native",
-            ""
-          ],
+          "enum": ["preserve", "react", "react-native", ""],
           "default": ""
         },
         "cssUrl": {
           "description": "Embed assets in css file using data URIs - see https://css-tricks.com/data-uris",
           "type": "string",
-          "enum": [
-            "none",
-            "inline"
-          ],
+          "enum": ["none", "inline"],
           "default": "none"
         },
         "sassIncludePaths": {
-          "description": "Any additional paths that should used to resolve SASS imports",
+          "description": "DEPRECATED: Please use styleIncludePaths",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "styleIncludePaths": {
+          "description": "Any additional paths that should be used to resolve style imports",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "languageLevel": {
-          "description": "Set typescript language level, i.e. tsconfig.lib. This will enable accessing typescript features available in es2016, es2017, etc.",
+          "description":
+            "Set typescript language level, i.e. tsconfig.lib. This will enable accessing typescript features available in es2016, es2017, etc.",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "default": [
-            "dom",
-            "es2015"
-          ]
+          "default": ["dom", "es2015"]
         }
       }
     }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[X] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

Updating the ng-package.json file to include a more generic option that also supports resolving Less and Stylus import paths to achieve feature parity with `@angular/cli`.

- Added styleIncludePaths option in ng-package.schema.json
- Updated README.md to refer to the new option name
- Updated entry-point.ts to use the new option (also uses older sassIncludePaths for backwards compatability).
- Updated stylesheet.transform.ts to pass the include paths to the Less and Stylus compilers.
- Updated the integration tests for scss-paths to also include tests for Less and Stylus

This should resolve the comments about feature parity in #282.

Closes #282 

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

I left the lib.sassIncludePaths option in place for backwards compatability