### PR TITLE
fix: pass 'setParentNodes' when calling 'createCompilerHost'

### DIFF
--- a/src/lib/ts/synthesized-compiler-host.ts
+++ b/src/lib/ts/synthesized-compiler-host.ts
@@ -13,6 +13,7 @@ export function createCompilerHostForSynthesizedSourceFiles(
   sourceFiles: ts.SourceFile[],
   compilerOptions: ts.CompilerOptions
 ): ts.CompilerHost {
+  // FIX(#625): pass `setParentNodes` to the "synthesized" compiler host
   const wrapped = ts.createCompilerHost(compilerOptions, /* setParentNodes */ true);
 
   return {

--- a/src/lib/ts/synthesized-compiler-host.ts
+++ b/src/lib/ts/synthesized-compiler-host.ts
@@ -13,7 +13,7 @@ export function createCompilerHostForSynthesizedSourceFiles(
   sourceFiles: ts.SourceFile[],
   compilerOptions: ts.CompilerOptions
 ): ts.CompilerHost {
-  const wrapped = ts.createCompilerHost(compilerOptions);
+  const wrapped = ts.createCompilerHost(compilerOptions, /* setParentNodes */ true);
 
   return {
     ...wrapped,


### PR DESCRIPTION
## I'm submitting a...

```
[X] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

This change passes 'setParentNodes' when calling 'createCompilerHost' as part of the "synthesized" compiler host wrapper.

This resolves an issue we have encountered with `compiler-cli` when it processes `SourceFile` objects
created by this wrapped CompilerHost, caused by the `parent` reference not being set on all AST nodes in the `SourceFile`:

```
TypeError: Cannot read property 'text' of undefined
    at TokenObject.TokenOrIdentifierObject.getText (node_modules\typescript\lib\typescript.js:90769:57)
    at Evaluator.evaluateNode (node_modules\@angular\compiler-cli\src\metadata\evaluator.js:604:66)
    ...
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
