### PR TITLE
feat: add `deleteOutputPath` option

### DIFF
--- a/integration/samples/keep-output-path/.gitignore
+++ b/integration/samples/keep-output-path/.gitignore
@@ -1,0 +1,4 @@
+dest/**/*.js
+dest/**/*.d.ts
+dest/**/*.json
+dest/**/*.map

--- a/integration/samples/keep-output-path/dest/file.txt
+++ b/integration/samples/keep-output-path/dest/file.txt
@@ -1,0 +1,1 @@
+hello world!

--- a/integration/samples/keep-output-path/ng-package.json
+++ b/integration/samples/keep-output-path/ng-package.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../src/ng-package.schema.json",
+  "deleteDestPath": false,
+  "dest": "dest",
+  "lib": {
+    "entryFile": "src/public_api.ts",
+    "embedded": ["chalk"]
+  }
+}

--- a/integration/samples/keep-output-path/package.json
+++ b/integration/samples/keep-output-path/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "keep-output-path",
+  "description": "A sample library with deleteDestPath setting set to false",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git"
+}

--- a/integration/samples/keep-output-path/specs/keep-file.ts
+++ b/integration/samples/keep-output-path/specs/keep-file.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+describe(`keep-output-path`, () => {
+  describe(`keep-file`, () => {
+    it(`should contain 'file.txt'`, () => {
+      const x = fs.readFileSync(path.resolve(__dirname, '..', 'dest', 'file.txt'), 'utf-8');
+      expect(x).to.contain('hello world');
+    });
+  });
+});

--- a/integration/samples/keep-output-path/src/public_api.ts
+++ b/integration/samples/keep-output-path/src/public_api.ts
@@ -1,0 +1,1 @@
+export const x = 'Hello World';

--- a/src/lib/ng-package-format/package.ts
+++ b/src/lib/ng-package-format/package.ts
@@ -34,15 +34,12 @@ import { DirectoryPath, SourceFilePath } from './shared';
  * @link https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/edit#
  */
 export class NgPackage {
-
   constructor(
     private readonly basePath: string,
-
     /**
      * A reference to the primary entry point.
      */
     public readonly primary: NgEntryPoint,
-
     /**
      * An array of seconary entry points.
      */
@@ -52,6 +49,11 @@ export class NgPackage {
   /** Absolute path of the package's source folder, derived from the user's (primary) package location. */
   public get src(): DirectoryPath {
     return this.basePath;
+  }
+
+  /** Delete output path before build */
+  public get deleteDestPath(): boolean {
+    return this.primary.$get('deleteDestPath');
   }
 
   /** Absolute path of the package's destination directory. */
@@ -69,8 +71,6 @@ export class NgPackage {
   }
 
   public entryPoint(moduleId: string): NgEntryPoint {
-    return [ this.primary, ...this.secondaries]
-      .find((entryPoint) => entryPoint.moduleId === moduleId);
+    return [this.primary, ...this.secondaries].find(entryPoint => entryPoint.moduleId === moduleId);
   }
-
 }

--- a/src/lib/ng-v5/package.transform.ts
+++ b/src/lib/ng-v5/package.transform.ts
@@ -55,7 +55,10 @@ export const packageTransformFactory = (
       );
     }),
     // Clean the primary dest folder (should clean all secondary sub-directory, as well)
-    switchMap(graph => fromPromise(rimraf(graph.get(pkgUri).data.dest)), (graph, _) => graph),
+    switchMap(graph => {
+      const { dest, deleteDestPath } = graph.get(pkgUri).data;
+      return fromPromise(deleteDestPath ? rimraf(dest) : Promise.resolve());
+    }, (graph, _) => graph),
     // Add entry points to graph
     map(graph => {
       const ngPkg = graph.get(pkgUri);

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -8,6 +8,11 @@
     "$schema": {
       "type": "string"
     },
+    "deleteDestPath": {
+      "description": "Delete output path before build.",
+      "type": "boolean",
+      "default": true
+    },
     "dest": {
       "description":
         "Destination folder where distributable binaries of the Angular library are written (default: `dist`).",


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
Provide an option for users to not delete output path before build. The name was choosen for feature parity with NG CLI.

Closes: #632

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
