### PR TITLE
fix: AMD module ID in UMD output

### DIFF
--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -74,6 +74,7 @@ export async function rollupBundleFile(opts: RollupOptions): Promise<void> {
   // Output the bundle to disk
   await bundle.write({
     name: `${opts.moduleName}`,
+    amd: { id: opts.moduleName },
     file: opts.dest,
     format: opts.format,
     banner: '',


### PR DESCRIPTION
closes #673

Set the UMD module ID per the Rollup API:

https://rollupjs.org/guide/en#exports

## Tests?

- [ ] Tests for the changes have been added


The test set up for ng-packagr is relatively complex, I studied it for a few minutes and it was not clear where to add the test for this. With a pointer or two though, I'm certain I could do so.

NOT a breaking change; does not break existing tests, and adding an AMD module ID should not interfere with typical anonymous use of the AMD define inside a UMD.
