### PR TITLE
fix: validate non-peerDependencies at build time

### DIFF
--- a/integration/samples.sh
+++ b/integration/samples.sh
@@ -13,9 +13,13 @@ do
     elif [ -f $P_JSON ]; then
         echo "Building sample ${P_JSON}..."
         node dist/cli/main.js -p ${P_JSON}
-    else
+    elif [ -f $P ]; then
         echo "Building sample ${P}..."
-        node dist/cli/main.js -p ${P}
+        if [ $P='failures' ]; then
+            node dist/cli/main.js -p ${P} || true
+        else
+            node dist/cli/main.js -p ${P}
+        fi
     fi
     echo "Built."
 done

--- a/integration/samples/failures/index.ts
+++ b/integration/samples/failures/index.ts
@@ -1,0 +1,1 @@
+export const PUBLISHING_NON_PEER_DEPENDENCIES = 'should fail';

--- a/integration/samples/failures/package.json
+++ b/integration/samples/failures/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "non-peer-deps",
+  "description": "https://github.com/dherges/ng-packagr/pull/687",
+  "dependencies": {
+    "foobar": "1.0.0"
+  },
+  "ngPackage": {
+    "dest": "./dist",
+    "lib": {
+      "entryFile": "index.ts"
+    }
+  }
+}

--- a/integration/samples/failures/specs/non-peer-deps.ts
+++ b/integration/samples/failures/specs/non-peer-deps.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+describe(`Failure Builds`, () => {
+  describe(`non-peer-deps`, () => {
+    it(`should have no build output`, () => {
+      const exists = fs.existsSync(path.resolve(__dirname, 'dist'));
+      expect(exists).to.be.false;
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -122,11 +122,14 @@
     "publish:ci": "yarn prerelease && yarn postrelease",
     "integration:samples": "integration/samples.sh",
     "integration:samples:dev": "ts-node --project src/tsconfig.packagr.json ./integration/samples.dev.ts",
-    "integration:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register integration/samples/*/specs/**/*.ts",
+    "integration:specs":
+      "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register \"integration/samples/*/specs/**/*.ts\"",
     "integration:consumers": "integration/consumers.sh",
     "integration:consumers:ngc": "ngc -p integration/consumers/tsc/tsconfig.json",
-    "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register \"src/**/*.spec.ts\"",
-    "test": "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:consumers",
+    "test:specs":
+      "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register \"src/**/*.spec.ts\"",
+    "test":
+      "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:consumers",
     "commitmsg": "commitlint -e",
     "precommit": "pretty-quick --staged",
     "gh-pages": "gh-pages -d docs/ghpages"

--- a/src/lib/ng-package-format/package.ts
+++ b/src/lib/ng-package-format/package.ts
@@ -73,8 +73,10 @@ export class NgPackage {
   public get whitelistedNonPeerDependencies(): string[] {
     // XX: default array values from JSON schema not recognized
     const defValue = ['tslib'];
+    const value = (this.primary.$get('whitelistedNonPeerDependencies') as string[]) || defValue;
 
-    return this.primary.$get('whitelistedNonPeerDependencies') || defValue;
+    // Always append 'tslib' and dedupe
+    return value.concat('tslib').filter((value, index, self) => self.indexOf(value) === index);
   }
 
   private absolutePathFromPrimary(key: string) {

--- a/src/lib/ng-package-format/package.ts
+++ b/src/lib/ng-package-format/package.ts
@@ -70,6 +70,13 @@ export class NgPackage {
     return this.primary.$get('keepLifecycleScripts') === true;
   }
 
+  public get whitelistedNonPeerDependencies(): string[] {
+    // XX: default array values from JSON schema not recognized
+    const defValue = ['tslib'];
+
+    return this.primary.$get('whitelistedNonPeerDependencies') || defValue;
+  }
+
   private absolutePathFromPrimary(key: string) {
     return path.resolve(this.basePath, this.primary.$get(key));
   }

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -31,6 +31,15 @@
       "type": "string",
       "default": ".ng_pkg_build"
     },
+    "whitelistedNonPeerDependencies": {
+      "description":
+        "A list of dependencies that are allowed in the 'dependendencies' and 'devDependencies' section of package.json. Values in the list are regular expressions matched against npm package names.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["tslib"]
+    },
     "lib": {
       "description": "Description of the library's entry point.",
       "type": "object",
@@ -83,7 +92,7 @@
           "default": "none"
         },
         "sassIncludePaths": {
-          "description": "DEPRECATED: Please use styleIncludePaths",
+          "description": "DEPRECATED: Please use styleIncludePaths. sassIncludePaths will be removed in v3!",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Publish npm packages with `dependencies` and/or `devDependencies` easily leads to installing multiple versions of a dependency to an application's `node_modules` folder. While this is a desirable solution on server-side or standalone programs, it's a source for bugs on front-end build stacks and UI technologies – you don't want to install two different versions of Angular, don't you?!

A motivation [why `peerDependencies` are the preferred solution for libraries](https://blog.domenic.me/peer-dependencies/) can be found on the Hidden Variables blog (the article is also cross-posted on the npm blog).

With this change, ng-packagr will verify `dependencies` and `devDependencies` at build time and fail the build, if the dependency is not whitelisted explicitly.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

Technically, this will break library builds that used to compile in prior versions of 2.x. However, the distribution-ready binaries were non-healthy to the ecosystem. As such, this change should be considered a fix to prevent you from bugs rather than a breakage of your build.