### PR TITLE
fix: move `keepLifecycleScripts` to ngPackage conf

### DIFF
--- a/integration/samples/core/specs/package.ts
+++ b/integration/samples/core/specs/package.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 
 describe(`@sample/core`, () => {
-
   describe(`package.json`, () => {
     let PACKAGE;
     before(() => {
@@ -32,5 +31,8 @@ describe(`@sample/core`, () => {
       expect(PACKAGE['typings']).to.equal('sample-core.d.ts');
     });
 
+    it(`should have 'scripts' section removed`, () => {
+      expect(PACKAGE['scripts']).to.be.undefined;
+    });
   });
 });

--- a/integration/samples/core/specs/ts-api.ts
+++ b/integration/samples/core/specs/ts-api.ts
@@ -1,12 +1,14 @@
 import { expect } from 'chai';
 import { Foo, Bar } from '../dist/sample-core';
 
-describe(`TypeScript API surface`, () => {
-  it(`export { Foo, Bar }`, () => {
-    const foo: Foo = { foo: 123 };
-    const bar: Bar = { bar: '123' };
+describe(`@sample/core`, () => {
+  describe(`TypeScript API surface (from '*.d.ts')`, () => {
+    it(`export { Foo, Bar }`, () => {
+      const foo: Foo = { foo: 123 };
+      const bar: Bar = { bar: '123' };
 
-    expect(foo.foo).to.equal(123);
-    expect(bar.bar).to.equal('123');
+      expect(foo.foo).to.equal(123);
+      expect(bar.bar).to.equal('123');
+    });
   });
 });

--- a/integration/samples/custom/ng-package.json
+++ b/integration/samples/custom/ng-package.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../../src/ng-package.schema.json",
+  "keepLifecycleScripts": true,
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/integration/samples/custom/specs/package.ts
+++ b/integration/samples/custom/specs/package.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 
 describe(`sample-custom`, () => {
-
   describe(`package.json`, () => {
     let PACKAGE;
     before(() => {
@@ -36,6 +35,10 @@ describe(`sample-custom`, () => {
 
     it(`should reference "typings" files`, () => {
       expect(PACKAGE['typings']).to.equal('sample-custom.d.ts');
+    });
+
+    it(`should keep 'scripts' section intact`, () => {
+      expect(PACKAGE['scripts']).to.be.ok;
     });
   });
 });

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -87,10 +87,6 @@ export class NgEntryPoint {
     }
   }
 
-  public get keepLifecycleScripts(): boolean {
-    return this.$get('lib.keepLifecycleScripts');
-  }
-
   public get jsxConfig(): string {
     return this.$get('lib.jsx');
   }

--- a/src/lib/ng-package-format/package.ts
+++ b/src/lib/ng-package-format/package.ts
@@ -66,6 +66,10 @@ export class NgPackage {
     return this.absolutePathFromPrimary('workingDirectory');
   }
 
+  public get keepLifecycleScripts(): boolean {
+    return this.primary.$get('keepLifecycleScripts') === true;
+  }
+
   private absolutePathFromPrimary(key: string) {
     return path.resolve(this.basePath, this.primary.$get(key));
   }

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -24,7 +24,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
   // 6. WRITE PACKAGE.JSON
   log.info('Writing package metadata');
   const relativeDestPath: string = path.relative(ngEntryPoint.destinationPath, ngPackage.primary.destinationPath);
-  await writePackageJson(ngEntryPoint, {
+  await writePackageJson(ngEntryPoint, ngPackage, {
     main: ensureUnixPath(path.join(relativeDestPath, 'bundles', ngEntryPoint.flatModuleFile + '.umd.js')),
     module: ensureUnixPath(path.join(relativeDestPath, 'esm5', ngEntryPoint.flatModuleFile + '.js')),
     es2015: ensureUnixPath(path.join(relativeDestPath, 'esm2015', ngEntryPoint.flatModuleFile + '.js')),
@@ -53,7 +53,11 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
  * @param entryPoint An entry point of an Angular package / library
  * @param binaries Binary artefacts (bundle files) to merge into `package.json`
  */
-export async function writePackageJson(entryPoint: NgEntryPoint, binaries: { [key: string]: string }): Promise<void> {
+export async function writePackageJson(
+  entryPoint: NgEntryPoint,
+  pkg: NgPackage,
+  binaries: { [key: string]: string }
+): Promise<void> {
   log.debug('Writing package.json');
   const packageJson: any = entryPoint.packageJson;
   // set additional properties
@@ -82,12 +86,14 @@ export async function writePackageJson(entryPoint: NgEntryPoint, binaries: { [ke
   // this will not throw if ngPackage field does not exist
   delete packageJson.ngPackage;
 
-  // removes scripts from package.json after build
-  if (entryPoint.keepLifecycleScripts !== true) {
+  // Removes scripts from package.json after build
+  if (pkg.keepLifecycleScripts !== true) {
     log.info(`Removing scripts section in package.json as it's considered a potential security vulnerability.`);
     delete packageJson.scripts;
   } else {
-    log.warn(`You enabled keepLifecycleScripts explicitly. The scripts section in package.json will be published to npm.`);
+    log.warn(
+      `You enabled keepLifecycleScripts explicitly. The scripts section in package.json will be published to npm.`
+    );
   }
 
   // `outputJson()` creates intermediate directories, if they do not exist

--- a/src/ng-package.schema.json
+++ b/src/ng-package.schema.json
@@ -19,6 +19,12 @@
       "type": "string",
       "default": "dist"
     },
+    "keepLifecycleScripts": {
+      "description":
+        "Enable this to keep the 'scripts' section in package.json. Read the NPM Blog on 'Package install scripts vulnerability' – http://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability",
+      "type": "boolean",
+      "default": false
+    },
     "workingDirectory": {
       "description":
         "Internal working directory of ng-packagr where intermediate build files are stored (default: `.ng_pkg_build`).",
@@ -98,11 +104,6 @@
             "type": "string"
           },
           "default": ["dom", "es2015"]
-        },
-        "keepLifecycleScripts": {
-          "description": "Enable this to keep the 'scripts' section in package.json. Read the NPM Blog on 'Package install scripts vulnerability' – http://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability",
-          "type": "boolean",
-          "default": false
         },
         "amdId": {
           "description":


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

See #686

Configuration location is:

```json
{
  "name": "@foo/bar",
  "ngPackage": {
    "keepLifecycleScripts": true,
    "lib": {
      /* .. things related to source code and bundle files .. */
    }
  }
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
