### PR TITLE
docs(readme): fix spelling error and phrasing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ The comments property can accept also a regex to selectively remove comments.
 
 #### License header
 
-To prepend a license header on your budles:
+To prepend a license header in your bundled files:
 
 ```
 {


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

On Line 302 of README.md: 
- "budles" is misspelled => "bundle."
- Proper phrasing would be "in your bundled files." instead of "on your bundles."

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
