### PR TITLE
feat: allow Angular 6 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "update-notifier": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/compiler": "^5.0.0",
-    "@angular/compiler-cli": "^5.0.0",
+    "@angular/compiler": "^5.0.0 || ^6.0.0-rc.0",
+    "@angular/compiler-cli": "^5.0.0 || ^6.0.0-rc.0",
     "tsickle": ">=0.25.5",
     "tslib": "^1.7.1",
     "typescript": ">=2.4.2"


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

I did some basic testing using `ng-packagr` with Angular 6 and it seemed to be ok.

What I did was:
- use `@angular/{compiler,compiler-cli}@6.0.0-rc.0`
- build a library with a ngmodule, component and service
- consume the library (via tsconfig paths to build artifacts) in a Angular app using `6.0.0-rc.0`, using the component and service
- serve the app in JIT and AOT modes,
- check the build for errors (saw none)
- check the served app in the browser for the component and service (were there)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
