### PR TITLE
perf: read content and map `async` in `minifyJsFile`

### DIFF
--- a/src/lib/flatten/uglify.ts
+++ b/src/lib/flatten/uglify.ts
@@ -11,11 +11,14 @@ export async function minifyJsFile(inputPath: string): Promise<string> {
 
   const outputPath: string = `${pathWithNoExtension}.min${fileExtension}`;
   const sourcemapOut: string = `${outputPath}.map`;
-  const inputFileBuffer: Buffer = await readFile(inputPath);
-  const inputSourceMapBuffer: Buffer = await readFile(`${inputPath}.map`);
+  const [inputFileBuffer, inputSourceMapBuffer]: Buffer[] = await Promise.all([
+    readFile(inputPath),
+    readFile(`${inputPath}.map`)
+  ]);
+
   const result = minify(inputFileBuffer.toString(), {
     sourceMap: {
-      content: inputSourceMapBuffer.toString(),
+      content: JSON.parse(inputSourceMapBuffer.toString()),
       url: basename(sourcemapOut)
     },
     parse: {


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

- JS map and content files can be read in parallel.

- `sourceMap` map content is expected to be a JSON object.



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
