### PR TITLE
fix: naming of warning for adding peerDependencies to package.json

### DIFF
--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -151,7 +151,7 @@ function checkNonPeerDependencies(packageJson: { [key: string]: any }, property:
         log.debug(`Dependency ${dep} is whitelisted in '${property}'`);
       } else {
         log.warn(
-          `Distributing npm packages with '${property}' is not recommended. Please consider adding ${dep} to 'peerDepenencies' or remove it from '${property}'.`
+          `Distributing npm packages with '${property}' is not recommended. Please consider adding ${dep} to 'peerDependencies' or remove it from '${property}'.`
         );
         throw new Error(`Dependency ${dep} must be explicitly whitelisted.`);
       }


### PR DESCRIPTION
## I'm submitting a...
Minor wording/spelling change to fix "peerDependencies" spelling in the warning output message.

```
[ ] Bug Fix
[ ] Feature
[ x ] Other (Refactoring, Added tests, Documentation, ...)
```

## Description

This is a minor change for the spelling of the peerDependencies.


## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```
