### PR TITLE
build: remove `DOM` from tsconfig

### DIFF
--- a/src/tsconfig.packagr.json
+++ b/src/tsconfig.packagr.json
@@ -7,7 +7,7 @@
     "inlineSourceMap": false,
     "inlineSources": true,
     "declaration": true,
-    "lib": ["es2015", "dom"],
+    "lib": ["es2015"],
     "outDir": "../dist",
     "experimentalDecorators": true,
     "noEmitOnError": true,


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description
This is a node library and thus DOM is not needed

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
