### PR TITLE
feat: add `"sideEffects": false` flag to dist-ready package.json

### DIFF
--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -58,7 +58,7 @@ describe(`@sample/apf`, () => {
     });
 
     it(`should apply the 'sideEffects: false' flag by default`, () => {
-      expect(PACKAGE['sideEffects'].to.be.false);
+      expect(PACKAGE['sideEffects']).to.be.false;
     });
   });
 
@@ -117,7 +117,7 @@ describe(`@sample/apf`, () => {
     });
 
     it(`should apply the 'sideEffects: false' flag by default`, () => {
-      expect(PACKAGE['sideEffects'].to.be.false);
+      expect(PACKAGE['sideEffects']).to.be.false;
     });
   });
 });

--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -56,6 +56,10 @@ describe(`@sample/apf`, () => {
     it(`should reference "metadata" file`, () => {
       expect(PACKAGE['metadata']).to.equal('sample-apf.metadata.json');
     });
+
+    it(`should apply the 'sideEffects: false' flag by default`, () => {
+      expect(PACKAGE['sideEffects'].to.be.false);
+    });
   });
 
   describe(`secondary/package.json`, () => {
@@ -110,6 +114,10 @@ describe(`@sample/apf`, () => {
 
     it(`should reference "metadata" file`, () => {
       expect(PACKAGE['metadata']).to.equal('sample-apf-secondary.metadata.json');
+    });
+
+    it(`should apply the 'sideEffects: false' flag by default`, () => {
+      expect(PACKAGE['sideEffects'].to.be.false);
     });
   });
 });

--- a/integration/samples/core/package.json
+++ b/integration/samples/core/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0-pre.0",
   "private": true,
   "repository": "https://github.com/dherges/ng-packagr.git",
+  "sideEffects": true,
   "peerDependencies": {
     "@angular/common": "^4.1.3",
     "@angular/core": "^4.1.3",

--- a/integration/samples/core/specs/package.ts
+++ b/integration/samples/core/specs/package.ts
@@ -34,5 +34,9 @@ describe(`@sample/core`, () => {
     it(`should have 'scripts' section removed`, () => {
       expect(PACKAGE['scripts']).to.be.undefined;
     });
+
+    it(`should keep the 'sideEffects: true' flag`, () => {
+      expect(PACKAGE['sideEffects']).to.be.true;
+    });
   });
 });

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -34,10 +34,15 @@ import { DirectoryPath, SourceFilePath, CssUrl, DestinationFiles } from './share
  */
 export class NgEntryPoint {
   constructor(
+    /** Values from the `package.json` file of this entry point. */
     public readonly packageJson: any,
+    /** Values from either the `ngPackage` option (from `package.json`) or values from `ng-package.json`. */
     public readonly ngPackageJson: NgPackageConfig,
+    /** Corresponding JSON schema class instantiated from `ngPackageJson` values. */
     private readonly $schema: SchemaClass<NgPackageConfig>,
+    /** Absolute directory path of this entry point's `package.json` location. */
     public readonly basePath: string,
+    /** XX: additional auto-configured data passed for scondary entry point's. Needs better docs. */
     private readonly secondaryData?: { [key: string]: any }
   ) {}
 
@@ -153,5 +158,16 @@ export class NgEntryPoint {
     } else {
       return this.moduleId.split('/').join(separator);
     }
+  }
+
+  /**
+   * Enables the `"sideEffects": false` flag in `package.json`.
+   * The flag is enabled and set to `false` by default which results in more aggressive optimizations applied by webpack v4 builds consuming the library.
+   * To override the default behaviour, you need to set `"sideEffects": true` explicitly in your `package.json`.
+   *
+   * @link https://github.com/webpack/webpack/tree/master/examples/side-effects
+   */
+  public get hasSideEffects(): boolean {
+    return this.packageJson['sideEffects'] === false;
   }
 }

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -168,6 +168,6 @@ export class NgEntryPoint {
    * @link https://github.com/webpack/webpack/tree/master/examples/side-effects
    */
   public get hasSideEffects(): boolean {
-    return this.packageJson['sideEffects'] === false;
+    return this.packageJson['sideEffects'] === true;
   }
 }

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -61,7 +61,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
 export async function writePackageJson(
   entryPoint: NgEntryPoint,
   pkg: NgPackage,
-  additionalProperties: { [key: string]: string }
+  additionalProperties: { [key: string]: string | boolean }
 ): Promise<void> {
   log.debug('Writing package.json');
   const packageJson: any = entryPoint.packageJson;

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -35,7 +35,8 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     typings: relativeUnixFromDestPath(destinationFiles.declarations),
     // XX 'metadata' property in 'package.json' is non-standard. Keep it anyway?
     metadata: relativeUnixFromDestPath(destinationFiles.metadata),
-    "side-effects": false
+    // webpack v4+ specific flag to enable advanced optimizations and code splitting
+    sideEffects: ngEntryPoint.hasSideEffects
   });
 
   log.success(`Built ${ngEntryPoint.moduleId}`);

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -34,7 +34,8 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     fesm2015: relativeUnixFromDestPath(destinationFiles.fesm2015),
     typings: relativeUnixFromDestPath(destinationFiles.declarations),
     // XX 'metadata' property in 'package.json' is non-standard. Keep it anyway?
-    metadata: relativeUnixFromDestPath(destinationFiles.metadata)
+    metadata: relativeUnixFromDestPath(destinationFiles.metadata),
+    "side-effects": false
   });
 
   log.success(`Built ${ngEntryPoint.moduleId}`);

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -56,18 +56,18 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
  * flattened JavaScript bundles, type definitions, (...).
  *
  * @param entryPoint An entry point of an Angular package / library
- * @param binaries Binary artefacts (bundle files) to merge into `package.json`
+ * @param additionalProperties Additional properties, e.g. binary artefacts (bundle files), to merge into `package.json`
  */
 export async function writePackageJson(
   entryPoint: NgEntryPoint,
   pkg: NgPackage,
-  binaries: { [key: string]: string }
+  additionalProperties: { [key: string]: string }
 ): Promise<void> {
   log.debug('Writing package.json');
   const packageJson: any = entryPoint.packageJson;
   // set additional properties
-  for (const fieldName in binaries) {
-    packageJson[fieldName] = binaries[fieldName];
+  for (const fieldName in additionalProperties) {
+    packageJson[fieldName] = additionalProperties[fieldName];
   }
 
   // read tslib version from `@angular/compiler` so that our tslib


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

By default, ng-packagr will apply the `"sideEffects": false` flag to the distribution-ready `package.json` files.

To disable the behaviour, users need to set `"sideEffects": true` in their source `package.json` files explicitly.

Adding the flag is recommended in Angular Package Format v6. More information:

> webpack v4 "sideEffects": false
> 
> As of webpack v4, packages that contain a special property called "sideEffects" set to false in their package.json, will be processed by webpack more aggressively than those that don't. The end result of these optimizations should be smaller bundle size and better code distribution in bundle chunks after code-splitting. This optimization can break your code if it contains non-local side-effects - this is however not common in Angular applications and it's a usually a sign of bad design. Our recommendation is for all packages to claim the side-effect free status by setting the sideEffects property to false, and that developers follow the Angular Style Guide which naturally results in code without non-local side-effects.

APF doc: https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview#heading=h.wdpbhi4bw1u8

Webpack docs: https://github.com/webpack/webpack/tree/master/examples/side-effects



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
