### PR TITLE
fix: incorrect `UMD` module id for `@angular/common/http/testing`

### DIFF
--- a/src/lib/flatten/umd-module-id-strategy.spec.ts
+++ b/src/lib/flatten/umd-module-id-strategy.spec.ts
@@ -63,6 +63,10 @@ describe(`rollup`, () => {
       expect(umdModuleIdStrategy('@angular/common/http')).to.equal('ng.common.http');
     });
 
+    it(`should map '@angular/common/http/testing' to 'ng.common.http.testing'`, () => {
+      expect(umdModuleIdStrategy('@angular/common/http/testing')).to.equal('ng.common.http.testing');
+    });
+
     it(`should map '@angular/platform-browser' to 'ng.platformBrowser'`, () => {
       expect(umdModuleIdStrategy('@angular/platform-browser')).to.equal('ng.platformBrowser');
     });

--- a/src/lib/flatten/umd-module-id-strategy.ts
+++ b/src/lib/flatten/umd-module-id-strategy.ts
@@ -6,15 +6,15 @@ export const umdModuleIdStrategy = (moduleId: string, umdModuleIds: { [key: stri
 
   let regMatch;
   if ((regMatch = /^\@angular\/platform-browser-dynamic(\/?.*)/.exec(moduleId))) {
-    return `ng.platformBrowserDynamic${regMatch[1]}`.replace('/', '.');
+    return `ng.platformBrowserDynamic${regMatch[1]}`.replace(/\//g, '.');
   }
 
   if ((regMatch = /^\@angular\/platform-browser(\/?.*)/.exec(moduleId))) {
-    return `ng.platformBrowser${regMatch[1]}`.replace('/', '.');
+    return `ng.platformBrowser${regMatch[1]}`.replace(/\//g, '.');
   }
 
   if ((regMatch = /^\@angular\/(.+)/.exec(moduleId))) {
-    return `ng.${regMatch[1]}`.replace('/', '.');
+    return `ng.${regMatch[1]}`.replace(/\//g, '.');
   }
 
   if (/^rxjs\/(add\/)?observable/.test(moduleId)) {


### PR DESCRIPTION
## I'm submitting a...

```
[X] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description
At the moment `@angular/common/http/testing` UMD module id is being generated as `ng.common.http/testing` which is not correct as it should be `ng.common.http.testing`

https://unpkg.com/@angular/common@5.2.10/bundles/common-http-testing.umd.js

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
