### PR TITLE
fix: missing 'declaration' option in tsconfig

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -55,6 +55,7 @@ export const initializeTsConfig = (defaultTsConfig: TsConfig, entryPoint: NgEntr
     sourceMap: true,
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     target: ts.ScriptTarget.ES2015,
+    declaration: true,
     lib: ['dom', 'es2015']
   };
 


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Set the "declaration" option to true by default (not overriding in order to keep to right error message).

Related issue : when building (with angular-cli --project mylib) with a custom tsConfig file, the following error occur at ngc step :
```
BUILD ERROR
error TS5052: Option 'declarationDir' cannot be specified without specifying option 'declaration'.

Error: error TS5052: Option 'declarationDir' cannot be specified without specifying option 'declaration'.

    at Object.<anonymous> (D:\git\myproj\web\js\node_modules\ng-packagr\lib\ngc\compile-source-files.js:62:68)
    at Generator.next (<anonymous>)
    at D:\git\myproj\js\node_modules\ng-packagr\lib\ngc\compile-source-files.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (D:\git\myproj\js\node_modules\ng-packagr\lib\ngc\compile-source-files.js:3:12)
    at Object.compileSourceFiles (D:\git\myproj\js\node_modules\ng-packagr\lib\ngc\compile-source-files.js:19:12)
    at Object.<anonymous> (D:\git\myproj\js\node_modules\ng-packagr\lib\ng-v5\entry-point\ts\compile-ngc.transform.js:42:34)
    at Generator.next (<anonymous>)
    at D:\git\myproj\js\node_modules\ng-packagr\lib\ng-v5\entry-point\ts\compile-ngc.transform.js:7:71
    at new Promise (<anonymous>)
```
The TsConfig param have the following value when debugging : 
```
{
   "project":"D:\\git\\myproj\\js\\tsconfig.libs.json",
   "rootNames":[
      "D:\\git\\myproj\\js\\projects\\common\\src\\public_api.ts"
   ],
   "options":{
      "emitDecoratorMetadata":true,
      "experimentalDecorators":true,
      "sourceMap":true,
      "moduleResolution":2,
      "target":2,
      "lib":[
         "lib.dom.d.ts",
         "lib.es2017.d.ts"
      ],
      "inlineSources":true,
      "importHelpers":true,
      "genDir":"D:\\git\\myproj\\js",
      "basePath":"D:\\git\\myproj\\js\\projects\\common\\src",
      "flatModuleId":"@myproj/common",
      "flatModuleOutFile":"myproj-common.js",
      "baseUrl":"D:\\git\\myproj\\js\\projects\\common\\src",
      "rootDir":"D:\\git\\myproj\\js\\projects\\common\\src",
      "outDir":"",
      "declarationDir":"D:\\git\\myproj\\js\\projects\\common\\src"
   },
   "errors":[

   ],
   "emitFlags":23
}
```
Until this PR is merged, adding ``declaration: true`` in the custom tsConfig file works.

Ping @dherges : please review and release asap, as this issue in a "breaking" one !

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
