### PR TITLE
fix: don't pass `emitFlags` leave it up to `ngc`

### DIFF
--- a/src/lib/ngc/compile-source-files.ts
+++ b/src/lib/ngc/compile-source-files.ts
@@ -44,7 +44,6 @@ export async function compileSourceFiles(
   const result = ng.performCompilation({
     rootNames: tsConfig.rootNames,
     options: tsConfigOptions,
-    emitFlags: tsConfig.emitFlags,
     emitCallback: createEmitCallback(tsConfigOptions),
     host: ngCompilerHost,
     oldProgram: ngProgram


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
If the consumer doesn't pass `flatModuleId` and `flatModuleOutFile` the emitFlag will be incorrect and the metadata file won't be flattened, even though these properties are later set by `ng-packagr`. Rely on `ngc` to set the proper emit flag based on the tsconfig options.

/cc @filipesilva  @dherges 

And thanks @filipesilva for highlighting this up and sorry for the inconvenience.
Relates to: https://github.com/angular/devkit/pull/794


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
