### PR TITLE
fix: remove nested `dist` folder

### DIFF
--- a/integration/samples/apf/specs/files.ts
+++ b/integration/samples/apf/specs/files.ts
@@ -9,6 +9,13 @@ describe(`@sample/apf`, () => {
     DIST = path.resolve(__dirname, '../dist');
   });
 
+  describe('dist', () => {
+    it(`should not have a nested 'dist' folder`, () => {
+      const dist = fs.existsSync(path.join(DIST, 'dist'));
+      expect(dist).to.be.false;
+    });
+  });
+
   describe(`FESM2015`, () => {
     it(`should contain 2 '.js.map' files`, () => {
       expect(glob.sync(`${DIST}/fesm2015/**/*.js.map`).length).equal(2);


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
At the moment, if he entry file is parallel to `dist` when copying the declaration files one will end up with `dist/dist`



## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
