### PR TITLE
feat: provide `UMD module` id defaults for `RXJS` v6

### DIFF
--- a/src/lib/flatten/umd-module-id-strategy.spec.ts
+++ b/src/lib/flatten/umd-module-id-strategy.spec.ts
@@ -3,56 +3,12 @@ import { umdModuleIdStrategy } from './umd-module-id-strategy';
 
 describe(`rollup`, () => {
   describe(`umdModuleIdStrategy()`, () => {
-    it(`should map 'rxjs/add/observable/bindCallback' to 'Rx.Observable'`, () => {
-      expect(umdModuleIdStrategy('rxjs/add/observable/bindCallback')).to.equal('Rx.Observable');
+    it(`should map 'rxjs' to 'rxjs'`, () => {
+      expect(umdModuleIdStrategy('rxjs')).to.equal('rxjs');
     });
 
-    it(`should map 'rxjs/TeardownLogic' to 'Rx'`, () => {
-      expect(umdModuleIdStrategy('rxjs/TeardownLogic')).to.equal('Rx');
-    });
-
-    it(`should map 'rxjs/add/operator/audit' to 'Rx.Observable.prototype'`, () => {
-      expect(umdModuleIdStrategy('rxjs/add/operator/audit')).to.equal('Rx.Observable.prototype');
-    });
-
-    it(`should map 'rxjs/observable' to 'Rx.Observable'`, () => {
-      expect(umdModuleIdStrategy('rxjs/observable')).to.equal('Rx.Observable');
-    });
-
-    it(`should map 'rxjs/observable/bindCallback' to 'Rx.Observable'`, () => {
-      expect(umdModuleIdStrategy('rxjs/observable/bindCallback')).to.equal('Rx.Observable');
-    });
-
-    it(`should map 'rxjs/operators' to 'Rx.Observable.prototype'`, () => {
-      expect(umdModuleIdStrategy('rxjs/operators')).to.equal('Rx.Observable.prototype');
-    });
-
-    it(`should map 'rxjs/operator/audit' to 'Rx.Observable.prototype'`, () => {
-      expect(umdModuleIdStrategy('rxjs/operator/audit')).to.equal('Rx.Observable.prototype');
-    });
-
-    it(`should map 'rxjs/operators/audit' to 'Rx.Observable.prototype'`, () => {
-      expect(umdModuleIdStrategy('rxjs/operator/audit')).to.equal('Rx.Observable.prototype');
-    });
-
-    it(`should map 'rxjs/symbol' to 'Rx.Symbol'`, () => {
-      expect(umdModuleIdStrategy('rxjs/symbol')).to.equal('Rx.Symbol');
-    });
-
-    it(`should map 'rxjs/symbol/iterator' to 'Rx.Symbol'`, () => {
-      expect(umdModuleIdStrategy('rxjs/symbol/iterator')).to.equal('Rx.Symbol');
-    });
-
-    it(`should map 'rxjs/scheduler' to 'Rx.Scheduler'`, () => {
-      expect(umdModuleIdStrategy('rxjs/scheduler')).to.equal('Rx.Scheduler');
-    });
-
-    it(`should map 'rxjs/scheduler/queue' to 'Rx.Scheduler'`, () => {
-      expect(umdModuleIdStrategy('rxjs/scheduler/queue')).to.equal('Rx.Scheduler');
-    });
-
-    it(`should map 'rxjs/util/TimeoutError' to 'Rx.TimeoutError'`, () => {
-      expect(umdModuleIdStrategy('rxjs/util/TimeoutError')).to.equal('Rx.TimeoutError');
+    it(`should map 'rxjs/operators' to 'rxjs.operators'`, () => {
+      expect(umdModuleIdStrategy('rxjs/operators')).to.equal('rxjs.operators');
     });
 
     it(`should map '@angular/core' to 'ng.core'`, () => {

--- a/src/lib/flatten/umd-module-id-strategy.ts
+++ b/src/lib/flatten/umd-module-id-strategy.ts
@@ -17,28 +17,12 @@ export const umdModuleIdStrategy = (moduleId: string, umdModuleIds: { [key: stri
     return `ng.${regMatch[1]}`.replace(/\//g, '.');
   }
 
-  if (/^rxjs\/(add\/)?observable/.test(moduleId)) {
-    return 'Rx.Observable';
+  if (moduleId === 'rxjs') {
+    return 'rxjs';
   }
 
-  if (/^rxjs\/scheduler/.test(moduleId)) {
-    return 'Rx.Scheduler';
-  }
-
-  if (/^rxjs\/symbol/.test(moduleId)) {
-    return 'Rx.Symbol';
-  }
-
-  if (/^rxjs\/(add\/)?operator/.test(moduleId)) {
-    return 'Rx.Observable.prototype';
-  }
-
-  if (/^rxjs\/[^\/]+$/.test(moduleId)) {
-    return 'Rx';
-  }
-
-  if ((regMatch = /^rxjs\/util\/(\/?.*)/.exec(moduleId))) {
-    return `Rx.${regMatch[1]}`;
+  if ((regMatch = /^rxjs\/(\/?.*)/.exec(moduleId))) {
+    return `rxjs.${regMatch[1]}`;
   }
 
   if (moduleId === 'tslib') {


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Removes UMD module ids for rxjs v5 as they conflict with rxjs v6. By default, ng-packagr now suppors rxjs v6.

BREAKING CHANGE: UMD module ids for rxjs v5 are now longer provided out-ot-the-box. Users whishing to a build library for `rxjs@5` (potentially relying on `rxjs-compat`), must provide the UMD module IDs in the `ngPackage.lib.umdModuleIds` section. Please take a look at the changeset of PR #840 to see what the UMD module IDs used to be for v5.

Closes #781, Closes #838


## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
