### PR TITLE
fix: create an array large enough to hold all buckets

### DIFF
--- a/integration/samples/secondary/feature-c/feature-c.ts
+++ b/integration/samples/secondary/feature-c/feature-c.ts
@@ -1,0 +1,4 @@
+import { FEATURE_A } from '@sample/secondary/feature-a';
+import { FEATURE_B } from '@sample/secondary/feature-b';
+
+export const FEATURE_C = `Feature C: ${FEATURE_A} ${FEATURE_B}`;

--- a/integration/samples/secondary/feature-c/package.json
+++ b/integration/samples/secondary/feature-c/package.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../../../src/package.schema.json",
+  "description":
+    "A secondary entry point (feature c) that depends on @sample/secondary/feature-a, @sample/secondary/feature-b and transitively on @sample/secondary/shared",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "feature-c.ts"
+    }
+  }
+}

--- a/src/lib/brocc/depth.spec.ts
+++ b/src/lib/brocc/depth.spec.ts
@@ -41,7 +41,7 @@ describe(`DepthBuilder`, () => {
     builder.add('h', 'j');
 
     const groups = builder.build();
-    expect(groups.length).to.equal(5);
+    expect(groups.length).to.equal(6);
     expect(groups[0]).to.have.same.members(['d', 'g', 'i', 'j']);
     expect(groups[1]).to.have.same.members(['e', 'f', 'h']);
     expect(groups[2]).to.have.same.members(['c']);

--- a/src/lib/brocc/depth.ts
+++ b/src/lib/brocc/depth.ts
@@ -93,7 +93,7 @@ export class DepthBuilder {
 
     // All nodes with the same max distance from a root can be run in parallel
     // Now we need to bucket nodes by max depth
-    const buckets: Token[][] = new Array<Token[]>(maxDepth);
+    const buckets: Token[][] = new Array<Token[]>(maxDepth + 1);
     for (let i = 0; i < buckets.length; i++) {
       buckets[i] = [];
     }


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [] Tests for the changes have been added


## Description

This will fix an error that appears only when using multiple secondary entry-points depending on each other.

Updated the examples to cause the error and fixed it with a proper initialization of the involved array holding our buckets. I'm not able to create a test for this scenario and think the samples will cover it properly.

That's the error it will fix:
```
Cannot read property 'push' of undefined
TypeError: Cannot read property 'push' of undefined
    at nodeDepths.forEach (/Users/geokal/job/opensource/ng-packagr/src/lib/brocc/depth.ts:107:22)
```


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
