### PR TITLE
fix: Depth analysis of unordered dependencies

### DIFF
--- a/src/lib/brocc/depth.spec.ts
+++ b/src/lib/brocc/depth.spec.ts
@@ -48,4 +48,25 @@ describe(`DepthBuilder`, () => {
     expect(groups[3]).to.have.same.members(['b']);
     expect(groups[4]).to.have.same.members(['a']);
   });
+
+  /**
+   * This scenario is visually documented:
+   * https://mermaidjs.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVERcbmIgLS0-IGRcbmIgLS0-IGNcbmIgLS0-IGVcbmEgLS0-IGJcbmEgLS0-IGRcbmEgLS0-IGNcbmEgLS0-IGVcbmQgLS0-IGVcbmMgLS0-IGRcbmMgLS0-IGUiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ
+   */
+  it(`should group an unordered complex scenario`, () => {
+    const builder = new DepthBuilder();
+    builder.add('b', ['d','c','e']);
+    builder.add('a', ['b', 'd', 'c', 'e']);
+    builder.add('d','e');
+    builder.add('c', ['d','e']);
+    builder.add('e');
+
+    const groups = builder.build();
+    expect(groups.length).to.equal(5);
+    expect(groups[0]).to.have.same.members(['e']);
+    expect(groups[1]).to.have.same.members(['d']);
+    expect(groups[2]).to.have.same.members(['c']);
+    expect(groups[3]).to.have.same.members(['b']);
+    expect(groups[4]).to.have.same.members(['a']);
+  });
 });

--- a/src/lib/brocc/depth.ts
+++ b/src/lib/brocc/depth.ts
@@ -86,6 +86,8 @@ export class DepthBuilder {
 
         const dependencyDepth = nodeDepths.get(parent.token);
         if (currentDepth > dependencyDepth) {
+          // Push the dependency to the queue again and track its depth
+          nodeQueue.push(parent);
           nodeDepths.set(parent.token, currentDepth);
         }
       });


### PR DESCRIPTION
## I'm submitting a...

```
[X] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

Fixes an issue that can occur in a library using multiple secondary entry-points that depends on each other if the dependencies are not parsed in a "correct" order.


The added unit test will, without the fix, throw the following exception:

>   1) DepthBuilder
       should group an unordered complex scenario:
     TypeError: Cannot read property 'push' of undefined
      at /workspace/src/lib/brocc/depth.ts:106:22
      at Map.forEach (<anonymous>)
      at DepthBuilder.build (src/lib/brocc/depth.ts:105:16)
      at Context.<anonymous> (src/lib/brocc/depth.spec.ts:64:28)

Logging the `nodeDepths` map reveals the following incorrect depth analysis:
> Map { 'e' => 0, 'b' => 2, 'd' => 1, 'c' => 2, 'a' => 3 }

With the fix the correct order is generated:
> Map { 'e' => 0, 'b' => 3, 'd' => 1, 'c' => 2, 'a' => 4 }

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
