### PR TITLE
fix: generate tarball only for primary entry point (one per npm package)

### DIFF
--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -34,8 +34,10 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
   });
 
   // 7. CREATE PACKAGE .TGZ
-  log.info('Creating package .tgz');
-  _tar(`${ngEntryPoint.destinationPath}.tgz`, ngEntryPoint.destinationPath);
+  if (ngPackage.primary === ngEntryPoint) {
+    log.info('Creating package .tgz');
+    _tar(`${ngEntryPoint.destinationPath}.tgz`, ngEntryPoint.destinationPath);
+  }
 
   log.success(`Built ${ngEntryPoint.moduleId}`);
 


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Version 2 Bugfix: generate the tarball only for the primary entry point (one `.tgz` per npm package)


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
