### PR TITLE
 feat: don't add dependency to `tslib` in secondary entrypoints

### DIFF
--- a/integration/samples/apf/specs/package.ts
+++ b/integration/samples/apf/specs/package.ts
@@ -13,6 +13,10 @@ describe(`@sample/apf`, () => {
       expect(PACKAGE).to.be.ok;
     });
 
+    it(`should have 'tslib' as a dependency`, () => {
+      expect(PACKAGE.dependencies.tslib).to.be.ok;
+    });
+
     it(`should not have ngPackage field`, () => {
       expect(PACKAGE.ngPackage).to.be.undefined;
     });
@@ -66,6 +70,10 @@ describe(`@sample/apf`, () => {
     let PACKAGE;
     before(() => {
       PACKAGE = require('../dist/secondary/package.json');
+    });
+
+    it(`should not have 'tslib' as a dependency`, () => {
+      expect(PACKAGE.dependencies && PACKAGE.dependencies.tslib).to.be.undefined;
     });
 
     it(`should exist`, () => {

--- a/src/lib/ng-package-format/entry-point.ts
+++ b/src/lib/ng-package-format/entry-point.ts
@@ -51,6 +51,11 @@ export class NgEntryPoint {
     return path.resolve(this.basePath, this.entryFile);
   }
 
+  /** Whether or not the entrypoint is secondary */
+  public get isSecondaryEntryPoint(): boolean {
+    return !!this.secondaryData;
+  }
+
   /** Absolute directory path of this entry point's 'package.json'. */
   public get destinationPath(): DirectoryPath {
     if (this.secondaryData) {

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -78,7 +78,8 @@ export async function writePackageJson(
   // read tslib version from `@angular/compiler` so that our tslib
   // version at least matches that of angular if we use require('tslib').version
   // it will get what installed and not the minimum version nor if it is a `~` or `^`
-  if (!(packageJson.dependencies && packageJson.dependencies.tslib)) {
+  // this is only required for primary
+  if (!entryPoint.isSecondaryEntryPoint && !(packageJson.dependencies && packageJson.dependencies.tslib)) {
     const { dependencies: angularDependencies = {} } = require('@angular/compiler/package.json');
     const tsLibVersion = angularDependencies.tslib;
 

--- a/src/tsconfig.packagr.json
+++ b/src/tsconfig.packagr.json
@@ -13,7 +13,8 @@
     "noEmitOnError": true,
     "noImplicitAny": false,
     "skipLibCheck": true, // due to: https://github.com/angular/angular/issues/23112
-    "types": ["node"]
+    "types": ["node"],
+    "typeRoots": ["../node_modules/@types"]
   },
   "files": ["cli/main.ts", "public_api.ts"],
   "exclude": ["**/*.spec.ts"]


### PR DESCRIPTION
## I'm submitting a...

```
[] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

`tslib` dependency is only needed at entry point level.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
