### PR TITLE
fix: do not disable fullTemplateTypeCheck when ES5 downleveling

### DIFF
--- a/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
+++ b/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
@@ -61,8 +61,7 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
       // the options are here, to improve the build time
       declaration: false,
       declarationDir: undefined,
-      skipMetadataEmit: true,
-      fullTemplateTypeCheck: false
+      skipMetadataEmit: true
     })
   ]);
 


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

In #826 the option was enabled in tsconfig.ngc.json and then in #812 the option was disabled again when downleveling to ES5. This then causes #822 to resurface again, which was supposedly fixed by #826.

No integration test has been added at this moment, I'm hoping this can get in during the RCs to get real world feedback if the function calls in decorator bugs are now actually fully resolved. With the changes in this PR applied to 3.0.0-rc4 I have been able to successfully build my project that was also suffering from this issue after upgrading from 2.4 to the 3.0 RC.

## More Information

After some two hour debug session in the guts of Angular's compiler, I finally tracked down angular/angular#23609 to originate from [this piece of code when reading the metadata of a library](https://github.com/angular/angular/blob/117c7eebc388ccc7a138a468d79adcd314630471/packages/compiler/src/aot/static_symbol_resolver.ts#L381-L385). As can be seen there, with certain conditions Angular rejects most of the class metadata such that function calls cannot be resolved, resulting in the error.

Following above condition [we follow the code into `summaryResolver.isLibraryFile`](https://github.com/angular/angular/blob/117c7eebc388ccc7a138a468d79adcd314630471/packages/compiler/src/aot/summary_resolver.ts#L52-L57) to find that it calls into [the compiler host to determine if the file not a source file](https://github.com/angular/angular/blob/117c7eebc388ccc7a138a468d79adcd314630471/packages/compiler-cli/src/transformers/compiler_host.ts#L480-L482) that is the actual culprit. Here we find that `skipTemplateCodegen` and `fullTemplateTypeCheck` ultimately affect the decision to elide some of the metadata.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```