### PR TITLE
perf: remove extra template type checking for downleveling

### DIFF
--- a/integration/samples/material/ui-lib.module.ts
+++ b/integration/samples/material/ui-lib.module.ts
@@ -1,21 +1,13 @@
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { FooComponent } from './foo/foo.component';
 import { BarComponent } from './bar/bar.component';
 import { FooBarComponent } from './foo-bar/foo-bar.component';
 import { BazComponent } from './baz/baz.component';
 
 @NgModule({
-  declarations: [
-    FooComponent,
-    BarComponent,
-    FooBarComponent,
-    BazComponent,
-  ],
-  exports: [
-    FooComponent,
-    BarComponent,
-    FooBarComponent,
-    BazComponent,
-  ]
+  imports: [RouterModule.forChild([])],
+  declarations: [FooComponent, BarComponent, FooBarComponent, BazComponent],
+  exports: [FooComponent, BarComponent, FooBarComponent, BazComponent]
 })
 export class UiLibModule {}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@angular/http": "~6.0.0",
     "@angular/language-service": "~6.0.0",
     "@angular/platform-browser": "~6.0.0",
+    "@angular/router": "~6.0.0",
     "@commitlint/cli": "^6.0.0",
     "@commitlint/config-angular": "^6.0.2",
     "@types/acorn": "^4.0.3",

--- a/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
+++ b/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
@@ -61,7 +61,9 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
       // the options are here, to improve the build time
       declaration: false,
       declarationDir: undefined,
-      skipMetadataEmit: true
+      skipMetadataEmit: true,
+      skipTemplateCodegen: true,
+      strictMetadataEmit: false
     })
   ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,12 @@
   dependencies:
     tslib "^1.9.0"
 
+"@angular/router@~6.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-6.0.1.tgz#bc4943b1798ed8f622f1a4f773ff5f01b5ab70de"
+  dependencies:
+    tslib "^1.9.0"
+
 "@commitlint/cli@^6.0.0":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-6.1.3.tgz#4606e138b05b43034dc84af15da18e2139058537"
@@ -4048,16 +4054,6 @@ sntp@2.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
   dependencies:
     hoek "4.x.x"
-
-source-map-resolve@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
-  dependencies:
-    atob "^2.0.0"
-    decode-uri-component "^0.2.0"
-    resolve-url "^0.2.1"
-    source-map-url "^0.4.0"
-    urix "^0.1.0"
 
 source-map-resolve@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
This is not needed for downleveling type checking can be skipped altogether.. 

https://github.com/dherges/ng-packagr/pull/860

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
