### PR TITLE
fix: remove duplicate declarations under `dist`

### DIFF
--- a/integration/samples/apf/specs/files.ts
+++ b/integration/samples/apf/specs/files.ts
@@ -114,17 +114,29 @@ describe('@sample/apf', () => {
     });
   });
 
-  describe('sample-apf.d.ts', () => {
-    it(`should exist`, () => {
-      const file = fs.existsSync(path.join(DIST, 'sample-apf.d.ts'));
-      expect(file).to.be.true;
+  describe('declarations', () => {
+    describe('sample-apf.d.ts', () => {
+      it(`should exist`, () => {
+        const file = fs.existsSync(path.join(DIST, 'sample-apf.d.ts'));
+        expect(file).to.be.true;
+      });
     });
-  });
 
-  describe('sample-apf-secondary.d.ts', () => {
-    it(`should exist`, () => {
-      const file = fs.existsSync(path.join(DIST, 'secondary', 'sample-apf-secondary.d.ts'));
-      expect(file).to.be.true;
+    describe('sample-apf-secondary.d.ts', () => {
+      it(`should exist`, () => {
+        const file = fs.existsSync(path.join(DIST, 'secondary', 'sample-apf-secondary.d.ts'));
+        expect(file).to.be.true;
+      });
+    });
+
+    describe('primary.component.d.ts', () => {
+      it(`should only exist in the dist/src`, () => {
+        let file = fs.existsSync(path.join(DIST, 'primary.component.d.ts'));
+        expect(file).to.be.false;
+
+        file = fs.existsSync(path.join(DIST, 'src', 'primary.component.d.ts'));
+        expect(file).to.be.true;
+      });
     });
   });
 });

--- a/integration/samples/apf/specs/files.ts
+++ b/integration/samples/apf/specs/files.ts
@@ -10,6 +10,13 @@ describe('@sample/apf', () => {
   });
 
   describe('dist', () => {
+    it('should contain a total of 115 files', () => {
+      // this is a safe guard / alternative to snapshots in order to
+      // protect ourselves from doing a change that will emit unexpected files.
+      const files = glob.sync(path.join(DIST, '**/*'));
+      expect(files.length).to.equals(115);
+    });
+
     it(`should not have a nested 'dist' folder`, () => {
       const dist = fs.existsSync(path.join(DIST, 'dist'));
       expect(dist).to.be.false;

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -20,7 +20,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
   log.info('Copying declaration files');
   // we don't want to copy `dist` and 'node_modules' declaration files but only files in source
   const declarationFiles = await globFiles(`${path.dirname(ngEntryPoint.entryFilePath)}/**/*.d.ts`, {
-    ignore: ['**/node_modules/**/*', ngPackage.dest]
+    ignore: ['**/node_modules/**/*', path.join(ngPackage.dest, '**/*')]
   });
 
   await copyFiles(declarationFiles, path.dirname(destinationFiles.declarations));


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

This bug was introduced with https://github.com/dherges/ng-packagr/pull/862

Basically declarations are being copied twice.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
