### PR TITLE
fix: embed tslib helpers in umd bundle

### DIFF
--- a/integration/samples/core/specs/sourcemaps.ts
+++ b/integration/samples/core/specs/sourcemaps.ts
@@ -44,9 +44,9 @@ describe(`@sample/core`, () => {
     });
 
     it(`should reference each 'sources' path with a common prefix`, () => {
-      const everyUeveryMe = (sourceMap.sources as string[]).every(
-        fileName => fileName.startsWith('ng://@sample/core') && fileName.endsWith('.ts')
-      );
+      const everyUeveryMe = (sourceMap.sources as string[])
+        .filter(fileName => fileName !== 'null')
+        .every(fileName => fileName.startsWith('ng://@sample/core') && fileName.endsWith('.ts'));
       expect(everyUeveryMe).to.be.true;
     });
   });

--- a/integration/samples/core/specs/umd.ts
+++ b/integration/samples/core/specs/umd.ts
@@ -17,8 +17,8 @@ describe(`@sample/core`, () => {
       expect(BUNDLE).to.contain(`global.sample.core = {}`);
     });
 
-    it(`should import TS helpers from 'tslib'`, () => {
-      expect(BUNDLE).to.contain('tslib');
+    it(`should not import TS helpers from 'tslib'`, () => {
+      expect(BUNDLE).not.to.contain('tslib');
     });
   });
 

--- a/integration/samples/externals/public_api.ts
+++ b/integration/samples/externals/public_api.ts
@@ -2,3 +2,4 @@ export * from './src/cdk';
 export * from './src/rxjs-lettable-operators';
 export * from './src/rxjs-operators';
 export * from './src/embedded';
+export * from './src/tslib';

--- a/integration/samples/externals/specs/fesm2015.ts
+++ b/integration/samples/externals/specs/fesm2015.ts
@@ -23,6 +23,10 @@ describe(`@sample/externals`, () => {
     it(`should import 'lodash.template`, () => {
       expect(BUNDLE).to.contain("from 'lodash.template'");
     });
+
+    it(`should import 'tslib`, () => {
+      expect(BUNDLE).to.contain("from 'tslib'");
+    });
   });
 });
 

--- a/integration/samples/externals/specs/umd.ts
+++ b/integration/samples/externals/specs/umd.ts
@@ -57,6 +57,10 @@ describe(`@sample/externals`, () => {
     it(`should embed 'template' function`, () => {
       expect(BUNDLE).to.contain('template(string, options, guard)');
     });
+
+    it(`should not import 'tslib`, () => {
+      expect(BUNDLE).to.not.contain("require('tslib')");
+    });
   });
 });
 

--- a/integration/samples/externals/src/tslib.ts
+++ b/integration/samples/externals/src/tslib.ts
@@ -1,0 +1,2 @@
+// TS will use the tslib helper for this
+export async function foo() {}

--- a/src/lib/flatten/external-module-id-strategy.spec.ts
+++ b/src/lib/flatten/external-module-id-strategy.spec.ts
@@ -31,8 +31,8 @@ describe(`rollup`, () => {
           expect(externalModuleIdStrategy.isExternalDependency('ui.core')).to.be.true;
         });
 
-        it(`should return 'true' for external module 'tslib'`, () => {
-          expect(externalModuleIdStrategy.isExternalDependency('tslib')).to.be.true;
+        it(`should return 'false' for external module 'tslib'`, () => {
+          expect(externalModuleIdStrategy.isExternalDependency('tslib')).to.be.false;
         });
       });
 
@@ -68,8 +68,8 @@ describe(`rollup`, () => {
           expect(externalModuleIdStrategy.isExternalDependency('ui.core')).to.be.true;
         });
 
-        it(`should return 'true' for external module 'tslib'`, () => {
-          expect(externalModuleIdStrategy.isExternalDependency('tslib')).to.be.true;
+        it(`should return 'false' for external module 'tslib'`, () => {
+          expect(externalModuleIdStrategy.isExternalDependency('tslib')).to.be.false;
         });
       });
     });

--- a/src/lib/flatten/external-module-id-strategy.ts
+++ b/src/lib/flatten/external-module-id-strategy.ts
@@ -15,8 +15,13 @@ export class ExternalModuleIdStrategy {
   isExternalDependency(moduleId: string): boolean {
     // more information about why we don't check for 'node_modules' path
     // https://github.com/rollup/rollup-plugin-node-resolve/issues/110#issuecomment-350353632
-    if (path.isAbsolute(moduleId) || moduleId.startsWith('.') || moduleId.startsWith('/')) {
-      // if it's either 'absolute', marked to embed, starts with a '.' or '/'
+    if (
+      path.isAbsolute(moduleId) ||
+      moduleId.startsWith('.') ||
+      moduleId.startsWith('/') ||
+      (this.moduleFormat === 'umd' && moduleId === 'tslib')
+    ) {
+      // if it's either 'absolute', marked to embed, starts with a '.' or '/' or is the umd bundle and is tslib
       return false;
     }
 


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

tslib helpers shouldn't be embedded in the UMD bundles. This was how ng-packagr 2.x worked and how angular itself works in all versions (inc 6.x):
https://npmcdn.com/@angular/common@6.0.1/bundles/common.umd.js
https://npmcdn.com/@angular/material@6.0.1/bundles/material.umd.js

If you search for `__` and you will see the helpers embedded and there is no mention of `tslib` in the source. 

I believe the reason for this is to make it easier for system.js users to consume angular. 

Any changes please give me a shout 😄 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
