### PR TITLE
refactor: rename method to be more descriptive

### DIFF
--- a/src/lib/flatten/external-module-id-strategy.ts
+++ b/src/lib/flatten/external-module-id-strategy.ts
@@ -20,7 +20,7 @@ export class ExternalModuleIdStrategy {
       return false;
     }
 
-    const externals = this.getBundledDependencies();
+    const externals = this.getNonBundledDependencies();
     if (
       Array.isArray(externals)
         ? !externals.some(x => x === moduleId || moduleId.startsWith(`${x}/`))
@@ -35,13 +35,12 @@ export class ExternalModuleIdStrategy {
   /**
    * Returns a array of strings or a RegExp of non-bundled dependencies.
    */
-  getBundledDependencies(): string[] | RegExp {
+  getNonBundledDependencies(): string[] | RegExp {
     const { bundledDependencies = [], dependencies = [] } = this.dependencyList;
 
     // return catch all for when there are no 'bundledDependencies' is very important for secondary entry
     // as if this is not the case everything will be bundled in the secondary entry point
     // since no dependencies are defined.
-
     if (this.moduleFormat !== 'umd' || !bundledDependencies.length) {
       return /./; // catch all as external
     }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Method name is doing the opposite

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
