### PR TITLE
refactor: clean up `ExternalModuleIdStrategy`

### DIFF
--- a/src/lib/flatten/external-module-id-strategy.ts
+++ b/src/lib/flatten/external-module-id-strategy.ts
@@ -15,12 +15,7 @@ export class ExternalModuleIdStrategy {
   isExternalDependency(moduleId: string): boolean {
     // more information about why we don't check for 'node_modules' path
     // https://github.com/rollup/rollup-plugin-node-resolve/issues/110#issuecomment-350353632
-    if (
-      path.isAbsolute(moduleId) ||
-      moduleId.startsWith('.') ||
-      moduleId.startsWith('/') ||
-      (this.moduleFormat === 'umd' && moduleId === 'tslib')
-    ) {
+    if (path.isAbsolute(moduleId) || moduleId.startsWith('.') || moduleId.startsWith('/')) {
       // if it's either 'absolute', marked to embed, starts with a '.' or '/' or is the umd bundle and is tslib
       return false;
     }
@@ -46,16 +41,16 @@ export class ExternalModuleIdStrategy {
     // return catch all for when there are no 'bundledDependencies' is very important for secondary entry
     // as if this is not the case everything will be bundled in the secondary entry point
     // since no dependencies are defined.
-    if (this.moduleFormat !== 'umd' || !bundledDependencies.length) {
+    if (this.moduleFormat !== 'umd') {
       return /./; // catch all as external
     }
 
+    // tslib should always be embeeded for umd modules
+    if (bundledDependencies.length === 0) {
+      return /^((?!tslib).)*$/;
+    }
+
     // filter out dependencies that are meant to be external
-    return (
-      dependencies
-        .filter(x => bundledDependencies.indexOf(x) < 0)
-        // 'tslib' must always be external even if it's not in dependencies because it will be added later in the final step
-        .concat('tslib')
-    );
+    return dependencies.filter(x => bundledDependencies.indexOf(x) < 0);
   }
 }


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

this is following comment 
https://github.com/dherges/ng-packagr/pull/868#discussion_r187790064

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
