### PR TITLE
fix: auto-wire paths for transitive dependencies of entry points

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -100,6 +100,13 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Sample: issue-852",
+      "program": "${workspaceRoot}/integration/samples.dev.js",
+      "args": ["issue-852"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Sample: externals",
       "program": "${workspaceRoot}/integration/samples.dev.js",
       "args": ["externals"]

--- a/integration/samples/issue-852/bar/package.json
+++ b/integration/samples/issue-852/bar/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+  }
+}

--- a/integration/samples/issue-852/bar/public-api.ts
+++ b/integration/samples/issue-852/bar/public-api.ts
@@ -1,0 +1,17 @@
+import { SomeComponent } from '@my/issue-852/some-component';
+import { Directive, InjectionToken, NgModule, Optional } from '@angular/core';
+
+export const BAR_TOKEN = new InjectionToken<string>('bar-token');
+
+@Directive({
+  selector: 'input[Bar]'
+})
+export class BarDirective {
+  constructor(@Optional() private _formField: SomeComponent) {}
+}
+
+@NgModule({
+  declarations: [BarDirective],
+  exports: [BarDirective]
+})
+export class BarModule {}

--- a/integration/samples/issue-852/foo/package.json
+++ b/integration/samples/issue-852/foo/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+  }
+}

--- a/integration/samples/issue-852/foo/public-api.ts
+++ b/integration/samples/issue-852/foo/public-api.ts
@@ -1,0 +1,12 @@
+import { Platform } from '@angular/cdk/platform';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { BAR_TOKEN } from '@my/issue-852/bar';
+
+@Injectable()
+export class FooClass {
+  constructor(
+    @Optional()
+    @Inject(BAR_TOKEN)
+    matDateLocale: string
+  ) {}
+}

--- a/integration/samples/issue-852/package.json
+++ b/integration/samples/issue-852/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@my/issue-852",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "test": "../../../node_modules/.bin/cross-env TS_NODE_PROJECT=../../../integration/tsconfig.specs.json ../../../node_modules/.bin/mocha --compilers ts:ts-node/register specs/**/*.ts"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+  }
+}

--- a/integration/samples/issue-852/public-api.ts
+++ b/integration/samples/issue-852/public-api.ts
@@ -1,0 +1,1 @@
+export const SOME_VALUE = 'hello';

--- a/integration/samples/issue-852/some-component/package.json
+++ b/integration/samples/issue-852/some-component/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+  }
+}

--- a/integration/samples/issue-852/some-component/public-api.ts
+++ b/integration/samples/issue-852/some-component/public-api.ts
@@ -1,0 +1,15 @@
+import { Component, NgModule } from '@angular/core';
+
+@Component({
+  selector: 'some-component',
+  template: ''
+})
+export class SomeComponent {
+  constructor() {}
+}
+
+@NgModule({
+  declarations: [SomeComponent],
+  exports: [SomeComponent]
+})
+export class SomeComponentModule {}

--- a/integration/samples/issue-852/spec/metadata.ts
+++ b/integration/samples/issue-852/spec/metadata.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`issue-852`, () => {
+  describe(`issue-852.metadata.json`, () => {
+    let METADATA;
+    before(() => {
+      METADATA = require('../dist/my-issue-852.metadata.json');
+    });
+
+    it(`should exist`, () => {
+      expect(METADATA).to.be.ok;
+    });
+
+    it(`should be version 4`, () => {
+      expect(METADATA.version).to.equal(4);
+    });
+
+    it(`should be "__symbolic": "module"`, () => {
+      expect(METADATA['__symbolic']).to.equal('module');
+    });
+
+    it(`should "importAs": "@my/issue-852"`, () => {
+      expect(METADATA['importAs']).to.equal('@my/issue-852');
+    });
+  });
+});

--- a/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
+++ b/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
@@ -18,26 +18,6 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
   const tsSources = entryPoint.find(isTypeScriptSources) as TypeScriptSourceNode;
   const tsConfig: TsConfig = entryPoint.data.tsConfig;
 
-  // Add paths mappings for dependencies
-  const entryPointDeps = entryPoint.filter(isEntryPoint) as EntryPointNode[];
-  if (entryPointDeps.length > 0) {
-    if (!tsConfig.options.paths) {
-      tsConfig.options.paths = {};
-    }
-
-    for (let dep of entryPointDeps) {
-      const { entryPoint, destinationFiles } = dep.data;
-      const depModuleId = entryPoint.moduleId;
-      const mappedPath = [destinationFiles.declarations];
-
-      if (!tsConfig.options.paths[depModuleId]) {
-        tsConfig.options.paths[depModuleId] = mappedPath;
-      } else {
-        tsConfig.options.paths[depModuleId].concat(mappedPath);
-      }
-    }
-  }
-
   // Compile TypeScript sources
   const { esm2015, esm5, declarations } = entryPoint.data.destinationFiles;
   const previousTransform = tsSources.data;

--- a/src/lib/ng-v5/init/init-tsconfig.transform.ts
+++ b/src/lib/ng-v5/init/init-tsconfig.transform.ts
@@ -2,18 +2,12 @@
 import { ParsedConfiguration } from '@angular/compiler-cli/src/perform_compile';
 import { Transform, transformFromPromise } from '../../brocc/transform';
 import { TsConfig, initializeTsConfig } from '../../ts/tsconfig';
-import * as log from '../../util/log';
-import { isEntryPoint } from '../nodes';
+import { isEntryPoint, EntryPointNode } from '../nodes';
 
 export const initTsConfigTransformFactory = (defaultTsConfig: TsConfig): Transform =>
   transformFromPromise(async graph => {
     // Initialize tsconfig for each entry point
-    const entryPoints = graph.filter(isEntryPoint);
-    for (let entryPoint of entryPoints) {
-      log.debug(`Initializing tsconfig for ${entryPoint.data.entryPoint.moduleId}`);
-      const tsConfig = initializeTsConfig(defaultTsConfig, entryPoint.data.entryPoint);
-      entryPoint.data.tsConfig = tsConfig;
-    }
-
+    const entryPoints = graph.filter(isEntryPoint) as EntryPointNode[];
+    initializeTsConfig(defaultTsConfig, entryPoints);
     return graph;
   });


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description

Config paths needs to be added for all entry points and are also required when analysing.
This change  makes sure that also transitive dependencies, like `a -> b -> c`, the path of `c` is configured when building `a`.

Closes #852

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
