### PR TITLE
fix: create an array large enough to hold all buckets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - '9'
   - '8'
   - '7'
   - '6'

--- a/integration/samples/failures/package.json
+++ b/integration/samples/failures/package.json
@@ -8,6 +8,9 @@
     "dest": "./dist",
     "lib": {
       "entryFile": "index.ts"
-    }
+    },
+    "whitelistedNonPeerDependencies": [
+      "foobar"
+    ]
   }
 }

--- a/integration/samples/failures/package.json
+++ b/integration/samples/failures/package.json
@@ -8,9 +8,6 @@
     "dest": "./dist",
     "lib": {
       "entryFile": "index.ts"
-    },
-    "whitelistedNonPeerDependencies": [
-      "foobar"
-    ]
+    }
   }
 }

--- a/src/lib/brocc/depth.spec.ts
+++ b/src/lib/brocc/depth.spec.ts
@@ -41,7 +41,7 @@ describe(`DepthBuilder`, () => {
     builder.add('h', 'j');
 
     const groups = builder.build();
-    expect(groups.length).to.equal(5);
+    expect(groups.length).to.equal(6);
     expect(groups[0]).to.have.same.members(['d', 'g', 'i', 'j']);
     expect(groups[1]).to.have.same.members(['e', 'f', 'h']);
     expect(groups[2]).to.have.same.members(['c']);

--- a/src/lib/brocc/depth.ts
+++ b/src/lib/brocc/depth.ts
@@ -93,7 +93,7 @@ export class DepthBuilder {
 
     // All nodes with the same max distance from a root can be run in parallel
     // Now we need to bucket nodes by max depth
-    const buckets: Token[][] = new Array<Token[]>(maxDepth);
+    const buckets: Token[][] = new Array<Token[]>(maxDepth + 1);
     for (let i = 0; i < buckets.length; i++) {
       buckets[i] = [];
     }


### PR DESCRIPTION
This will fix an error that appears only when using multiple secondary entry-points depending on each other.

Error being fixed:
```
Cannot read property 'push' of undefined
TypeError: Cannot read property 'push' of undefined
    at nodeDepths.forEach (/Users/geokal/job/opensource/ng-packagr/src/lib/brocc/depth.ts:107:22)
```

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
