### PR TITLE
fix: throw an error when a circular dependency is detected

### DIFF
--- a/integration/consumers/ng-cli/package-lock.json
+++ b/integration/consumers/ng-cli/package-lock.json
@@ -1693,18 +1693,6 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "circular-dependency-plugin": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.0.2.tgz",
-      "integrity": "sha512-oC7/DVAyfcY3UWKm0sN/oVoDedQDQiw/vIiAnuTWTpE5s0zWf7l3WY417Xw/Fbi/QbAjctAkxgMiS9P0s3zkmA==",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.3.tgz",
-      "integrity": "sha512-YlxLOimeIoQGHnMe3kbf8qIV2Bj7uXLbljMPRguNT49GmSAzooNfS9EJ91rSJKbLBOOzM5agvtx0WyechZN/Hw==",
-      "dev": true
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",

--- a/src/lib/ng-v5/init/analyse-sources.transform.ts
+++ b/src/lib/ng-v5/init/analyse-sources.transform.ts
@@ -36,9 +36,11 @@ export const analyseSourcesTransform: Transform = pipe(
         log.debug(`Found dependency in ${sourceFile.fileName}: ${moduleId}`);
         const dep = entryPoints.find(ep => ep.data.entryPoint.moduleId === moduleId);
         if (dep) {
-          log.debug(
-            `Found entry point dependency: ${entryPoint.data.entryPoint.moduleId} -> ${dep.data.entryPoint.moduleId}`
-          );
+          if (entryPoint.data.entryPoint.moduleId === moduleId) {
+            throw new Error(`Entry point ${moduleId} has a circular dependency on itself.`);
+          }
+
+          log.debug(`Found entry point dependency: ${entryPoint.data.entryPoint.moduleId} -> ${moduleId}`);
           entryPoint.dependsOn(dep);
         }
       });


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [x] Tests for the changes have been added


## Description
At the moment, when a library depends on itself, it fails silently without any error.

Closes: #855


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
