### PR TITLE
feat: show filename for minify warnings (#882)

### DIFF
--- a/src/lib/flatten/uglify.ts
+++ b/src/lib/flatten/uglify.ts
@@ -12,21 +12,24 @@ export async function minifyJsFile(inputPath: string, outputPath?: string): Prom
     readFile(`${inputPath}.map`)
   ]);
 
-  const result = minify(inputFileBuffer.toString(), {
-    sourceMap: {
-      includeSources: true,
-      content: JSON.parse(inputSourceMapBuffer.toString()),
-      url: basename(sourcemapOut)
-    },
-    parse: {
-      bare_returns: true
-    },
-    ie8: true,
-    warnings: true,
-    output: {
-      comments: 'some'
+  const result = minify(
+    { [inputPath]: inputFileBuffer.toString() },
+    {
+      sourceMap: {
+        includeSources: true,
+        content: JSON.parse(inputSourceMapBuffer.toString()),
+        url: basename(sourcemapOut)
+      },
+      parse: {
+        bare_returns: true
+      },
+      ie8: true,
+      warnings: true,
+      output: {
+        comments: 'some'
+      }
     }
-  });
+  );
 
   if (result.warnings) {
     for (const warningMessage of result.warnings) {


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

This adds the actual filename of the UMD bundle which is passed to the minify process and should help the normal user to identify the bundled source file which originated the warnings.

There is also https://github.com/mishoo/UglifyJS2/issues/516 which tracks using the source-maps to display the correct originating file of the warning.

All the reformatting has been done but the git commit automatically. This is hopefully intentional, I actually only changed a single line.

I haven't added a unit test for this but checked that the current suite passed. If there is any clever idea how to add unit tests for this, I'm open for it :)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
