### PR TITLE
fix sub-packages docs default public_api location

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ my_package
 ├── package.json
 └── testing
     ├── src
+    |   ├── public_api.ts
     |   └── *.ts
-    ├── public_api.ts
     └── package.json
 ```
 


### PR DESCRIPTION
The default location for `public_api.ts` in a sub-package is within the `package-name/src` dir not in the root of the sub-package.

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
fix docs
```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

_please describe the changes that you are making_

_for features, please describe how to use the new feature_

_please include a reference to an existing issue, if applicable_


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
