### PR TITLE
perf: speed up discovery of secondary entry points

### DIFF
--- a/src/lib/ng-v5/discover-packages.ts
+++ b/src/lib/ng-v5/discover-packages.ts
@@ -86,19 +86,18 @@ const primaryEntryPoint = ({ packageJson, ngPackageJson, basePath }: UserPackage
  * @param excludeFolder A sub-folder of `directoryPath` that is excluded from search results.
  */
 const findSecondaryPackagesPaths = async (directoryPath: string, excludeFolder: string): Promise<string[]> => {
-  const excludedFolders = ['node_modules', 'dist', path.resolve(directoryPath, excludeFolder)];
-
-  const EXCLUDE_FOLDERS = [];
-  for (let folder of excludedFolders) {
-    EXCLUDE_FOLDERS.push(`**/${folder}/**/package.json`, `**/${folder}/**/ng-package.json`);
-  }
-  EXCLUDE_FOLDERS.push(`${directoryPath}/package.json`, `${directoryPath}/ng-package.json`);
+  const ignore = [
+    '**/node_modules/**/*',
+    `${path.resolve(directoryPath, excludeFolder)}/**/*`,
+    `${directoryPath}/package.json`
+  ];
 
   const filePaths = await globFiles(`${directoryPath}/**/package.json`, {
-    ignore: EXCLUDE_FOLDERS,
+    ignore,
     cwd: directoryPath
   });
-  return filePaths.map(path.dirname).filter((value, index, array) => array.indexOf(value) === index);
+
+  return filePaths.map(path.dirname);
 };
 
 /**


### PR DESCRIPTION


## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

`node_modules` were still being scanned as the folder was not being ignored.

Closes: #921
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
