### PR TITLE
perf: don't scan `node_modules` directory while globbing (V3)

### DIFF
--- a/src/lib/ng-v5/discover-packages.ts
+++ b/src/lib/ng-v5/discover-packages.ts
@@ -87,8 +87,8 @@ const primaryEntryPoint = ({ packageJson, ngPackageJson, basePath }: UserPackage
  */
 const findSecondaryPackagesPaths = async (directoryPath: string, excludeFolder: string): Promise<string[]> => {
   const ignore = [
-    '**/node_modules/**/*',
-    `${path.resolve(directoryPath, excludeFolder)}/**/*`,
+    '**/node_modules/**',
+    `${path.resolve(directoryPath, excludeFolder)}/**`,
     `${directoryPath}/package.json`
   ];
 

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -20,7 +20,7 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
   log.info('Copying declaration files');
   // we don't want to copy `dist` and 'node_modules' declaration files but only files in source
   const declarationFiles = await globFiles(`${path.dirname(ngEntryPoint.entryFilePath)}/**/*.d.ts`, {
-    ignore: ['**/node_modules/**/*', path.join(ngPackage.dest, '**/*')]
+    ignore: ['**/node_modules/**', `${ngPackage.dest}/**`]
   });
 
   await copyFiles(declarationFiles, path.dirname(destinationFiles.declarations));


### PR DESCRIPTION


## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

Change ignore glob from `**/node_modules/**/*` to `**/node_modules/**` the last will improve performance as it won't scan the complete tree.

Closes: #948
