### PR TITLE
fix: release typescript compiler memory allocations

### DIFF
--- a/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
+++ b/src/lib/ng-v5/entry-point/ts/compile-ngc.transform.ts
@@ -49,5 +49,10 @@ export const compileNgcTransform: Transform = transformFromPromise(async graph =
 
   previousTransform.dispose();
 
+  // Clean up TypeScript compiler nodes. Releases TypeScript memory allocations to avoid memory
+  // leaks with multiple secondary entry points.
+  tsSources.data.dispose();
+  tsSources.data = null;
+
   return graph;
 });


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

We have a memory leak because memory allocs of the TypeScirpt compiler are not released. The effect becomes worse with the number of secondary entry points, as memory allocations were kept for each entry point.

The change disposes the TypeScript transformation result and releases it from the build graph.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
