### PR TITLE
ci: fixes error on windows ci

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,8 @@
 environment:
+  global:
+    # Set %PATH% to avoid msys/cygwin DLL conflicts which causes:
+    # 'fatal error - cygheap base mismatch detected'
+    PATH: C:\msys64\usr\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files (x86)\Yarn\bin;C:\Program Files (x86)\nodejs
   nodejs_version: "8"
 
 matrix:
@@ -6,10 +10,10 @@ matrix:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - node --version
   - yarn install --frozen-lockfile --non-interactive
 
 test_script:
-  - node --version
   - yarn test
 
 build: off

--- a/integration/consumers.sh
+++ b/integration/consumers.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -e
 
-parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd "$parent_path"
-echo "Running consumer builds in $parent_path"
-
+cd "integration"
+echo "Running consumer builds in $PWD"
 # Prepare samples
 array=( 'custom' 'material' 'secondary' )
 for sample in "${array[@]}"; do

--- a/integration/samples.sh
+++ b/integration/samples.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e
 
-for D in `find ./integration/samples/* -maxdepth 0 -type d`
+FIND_COMMAND=""
+
+if [[ $OSTYPE == "win32" ]]; then
+    FIND_COMMAND="dir /b /o:n /ad"
+else
+    FIND_COMMAND="find ./integration/samples/* -maxdepth 0 -type d"
+fi
+
+for D in $FIND_COMMAND
 do
     P_JS=${D}/ng-package.js
     P_JSON=${D}/ng-package.json

--- a/integration/samples/core/specs/es2015-api.ts
+++ b/integration/samples/core/specs/es2015-api.ts
@@ -3,13 +3,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe(`@sample/core`, () => {
-  describe(`esm2015/sample-core.js`, () => {
+  describe(`fesm2015/sample-core.js`, () => {
     let API;
     let BUNDLE;
 
     before(() => {
-      API = require('../dist/esm2015/sample-core.js');
-      BUNDLE = fs.readFileSync(path.resolve(__dirname, '../dist/esm2015/sample-core.js'), 'utf-8');
+      API = require('../dist/fesm2015/sample-core.js');
+      BUNDLE = fs.readFileSync(path.resolve(__dirname, '../dist/fesm2015/sample-core.js'), 'utf-8');
     });
 
     it(`should exist`, () => {


### PR DESCRIPTION
Samples - the following error was being emitted `FIND: Parameter format not correct`, this is due that `find` is different in Unix and Windows system.

Consumers - fix `fatal error - cygheap base mismatch detected`

Closes: #962