### PR TITLE
fix: debounce when a file changes

### DIFF
--- a/src/lib/file/file-watcher.ts
+++ b/src/lib/file/file-watcher.ts
@@ -23,7 +23,7 @@ export function createFileWatch(
   });
 
   const handleFileChange = (event: FileWatchEvent, filePath: string, observer: Observer<FileChangedEvent>) => {
-    log.debug(`Watch: file changed ${filePath}`);
+    log.debug(`Watch: Path changed. Event: ${event}, Path: ${filePath}`);
 
     observer.next({
       filePath: path.resolve(ensureUnixPath(filePath)),

--- a/src/lib/ng-v5/package.transform.ts
+++ b/src/lib/ng-v5/package.transform.ts
@@ -1,5 +1,5 @@
 import { Observable, concat as concatStatic, from as fromPromise, of as observableOf, pipe, EMPTY } from 'rxjs';
-import { concatMap, map, switchMap, takeLast, tap, mapTo, catchError, startWith, throttleTime } from 'rxjs/operators';
+import { concatMap, map, switchMap, takeLast, tap, mapTo, catchError, startWith, debounceTime } from 'rxjs/operators';
 import { BuildGraph } from '../brocc/build-graph';
 import { DepthBuilder } from '../brocc/depth';
 import { STATE_IN_PROGESS } from '../brocc/node';
@@ -115,10 +115,10 @@ const watchTransformFactory = (
             }
           })
         ),
+        debounceTime(200),
         tap(() => log.msg(FileChangeDetected)),
         startWith(undefined),
-        mapTo(graph),
-        throttleTime(200)
+        mapTo(graph)
       );
     }),
     switchMap(graph => {


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description
In some cases on windows the same event is emitted twice. Instead of throttle we should debounce. Also, the same think happens when a folder is renamed, While we do have a swictchMap it's still better to trigger it once, in order not to end up with an invalid state,

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
