### PR TITLE
docs: tsconfig.ngc.json extension

### DIFF
--- a/docs/override-tsconfig.md
+++ b/docs/override-tsconfig.md
@@ -42,7 +42,21 @@ ngPackage
   });
 ```
 
-Note: You need to supply a full and valid tsconfig. You can get started by taking a look at [our internal tsconfig](../src/lib/ts/conf/tsconfig.ngc.json).
+Notes:
+
+You need to supply a full and valid tsconfig. You can get started by taking a look at [our internal tsconfig](../src/lib/ts/conf/tsconfig.ngc.json).
+
+Your `tsconfig.lib.json` can extends it
+
+```json
+{
+  "extends": "<root>/node_modules/ng-packagr/lib/ts/conf/tsconfig.ngc.json",
+  "compilerOptions": {
+    "types": ["node"]
+    // Other overrides
+  }
+}
+```
 
 ## Angular CLI Users
 


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[X] Other: Documentation
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [NA] Tests for the changes have been added


## Description

I ran into an issue with my ambient types because `@types/sinon` includes [conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#conditional-types) which are a `TypeScript@2.8` feature. My `tsconfig.json` exclude `sinon` ambient types but this is not the case in internal `tsconfig.ngc.json`. I found the docs on overriding tsconfig and I wanted to share the `extends` solution.


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
