### PR TITLE
perf: add teardown logic for watch

### DIFF
--- a/src/lib/file/file-watcher.ts
+++ b/src/lib/file/file-watcher.ts
@@ -33,5 +33,6 @@ export function createFileWatch(
 
   return Observable.create(observer => {
     watch.on('all', (event: FileWatchEvent, filePath: string) => handleFileChange(event, filePath, observer));
+    return () => watch.close();
   });
 }


### PR DESCRIPTION
When the observable has complete or errored. The watch should be closed.

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [X] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description
apply tier down logic so that when observable completes we close the watcher and thus avoid memory leaks

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
