### PR TITLE
refactor: remove custom delete strategy for filecache

### DIFF
--- a/integration/tsconfig.specs.json
+++ b/integration/tsconfig.specs.json
@@ -1,14 +1,7 @@
 {
-  "buildOnSave": false,
-  "compileOnSave": false,
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "allowJs": true,
-    "experimentalDecorators": true,
-    "lib": ["es2015", "es2016"],
-    "types": ["chai", "mocha", "node", "sinon"],
-    "typeRoots": ["../node_modules/@types"]
+    "allowJs": true
   },
-  "include": ["**/specs/*.ts"],
-  "exclude": [".ng_build", ".ng_pkgr_build", ".ng_pkg_build"]
+  "include": ["**/specs/*.ts"]
 }

--- a/src/lib/file/file-cache.spec.ts
+++ b/src/lib/file/file-cache.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { FileCache, DeleteStrategy } from './file-cache';
+import { FileCache } from './file-cache';
 
 describe('FileCache', () => {
   let cache: FileCache;
@@ -16,14 +16,8 @@ describe('FileCache', () => {
     expect(cache.getOrCreate('not-available')).to.ok;
   });
 
-  it(`should delete only a single with default 'DeleteStrategy'`, () => {
+  it(`should delete only a single file`, () => {
     cache.delete('/component/component-primary.scss');
     expect(cache.size()).to.equal(3);
-  });
-
-  it(`should delete all similar files when setting 'PartialMatch' as 'DeleteStrategy'`, () => {
-    cache.delete('/component', DeleteStrategy.PartialMatch);
-    expect(cache.size()).to.equal(1);
-    expect(cache.has('/service/component-service.ts')).to.equal(true);
   });
 });

--- a/src/lib/file/file-cache.ts
+++ b/src/lib/file/file-cache.ts
@@ -7,11 +7,6 @@ export interface CacheEntry {
   content?: string;
 }
 
-export const enum DeleteStrategy {
-  FullMatch = 0,
-  PartialMatch = 1
-}
-
 export class FileCache {
   private cache: Map<string, CacheEntry> = new Map();
 
@@ -29,21 +24,9 @@ export class FileCache {
     return ensureUnixPath(fileName);
   }
 
-  delete(fileName: string, deleteStrategy: DeleteStrategy = DeleteStrategy.FullMatch): boolean {
+  delete(fileName: string): boolean {
     const normalizedKey = this.normalizeKey(fileName);
-    if (deleteStrategy === DeleteStrategy.FullMatch) {
-      return this.cache.delete(this.normalizeKey(fileName));
-    }
-
-    let deleted: boolean;
-    this.cache.forEach((_value, key) => {
-      const normalizedFileKey = this.normalizeKey(key);
-      if (normalizedFileKey.startsWith(normalizedKey)) {
-        deleted = this.cache.delete(normalizedFileKey) || deleted;
-      }
-    });
-
-    return deleted;
+    return this.cache.delete(this.normalizeKey(fileName));
   }
 
   has(fileName: string): boolean {

--- a/src/lib/file/file-watcher.ts
+++ b/src/lib/file/file-watcher.ts
@@ -5,6 +5,7 @@ import { ensureUnixPath } from '../util/path';
 import * as log from '../util/log';
 
 export type FileWatchEvent = 'change' | 'unlink' | 'add' | 'unlinkDir' | 'addDir';
+
 export interface FileChangedEvent {
   filePath: string;
   event: FileWatchEvent;
@@ -24,6 +25,13 @@ export function createFileWatch(
 
   const handleFileChange = (event: FileWatchEvent, filePath: string, observer: Observer<FileChangedEvent>) => {
     log.debug(`Watch: Path changed. Event: ${event}, Path: ${filePath}`);
+
+    const ignoredEvents: FileWatchEvent[] = ['unlinkDir', 'addDir'];
+
+    if (ignoredEvents.includes(event)) {
+      // we don't need to trigger on directory removed or renamed as chokidar will fire the changes for each file
+      return;
+    }
 
     observer.next({
       filePath: path.resolve(ensureUnixPath(filePath)),

--- a/src/lib/ng-v5/package.transform.ts
+++ b/src/lib/ng-v5/package.transform.ts
@@ -11,7 +11,6 @@ import { PackageNode, EntryPointNode, ngUrl, isEntryPoint, byEntryPoint, isPacka
 import { discoverPackages } from './discover-packages';
 import { createFileWatch } from '../file/file-watcher';
 import { NgPackagrOptions } from './options.di';
-import { DeleteStrategy } from '../file/file-cache';
 
 /**
  * A transformation for building an npm package:
@@ -106,13 +105,8 @@ const watchTransformFactory = (
             const { analysisFileCache, compilationFileCache } = node.cache;
             const { filePath } = fileChange;
 
-            if (fileChange.event === 'unlinkDir') {
-              analysisFileCache.delete(filePath, DeleteStrategy.PartialMatch);
-              compilationFileCache.delete(filePath, DeleteStrategy.PartialMatch);
-            } else {
-              analysisFileCache.delete(filePath);
-              compilationFileCache.delete(filePath);
-            }
+            analysisFileCache.delete(filePath);
+            compilationFileCache.delete(filePath);
           })
         ),
         debounceTime(200),

--- a/src/tsconfig.packagr.json
+++ b/src/tsconfig.packagr.json
@@ -1,20 +1,10 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "inlineSourceMap": false,
-    "inlineSources": true,
     "declaration": true,
-    "lib": ["es2015"],
     "outDir": "../dist",
-    "experimentalDecorators": true,
-    "noEmitOnError": true,
-    "noImplicitAny": false,
     "skipLibCheck": true, // due to: https://github.com/angular/angular/issues/23112
-    "types": ["node"],
-    "typeRoots": ["../node_modules/@types"]
+    "types": ["node"]
   },
   "files": ["cli/main.ts", "public_api.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/src/tsconfig.specs.json
+++ b/src/tsconfig.specs.json
@@ -1,13 +1,4 @@
 {
-  "buildOnSave": false,
-  "compileOnSave": false,
-  "compilerOptions": {
-    "target": "es5",
-    "allowJs": true,
-    "experimentalDecorators": true,
-    "lib": ["es2015", "es2016"],
-    "types": ["chai", "mocha", "node", "sinon"],
-    "typeRoots": ["../node_modules/@types"]
-  },
+  "extends": "../tsconfig.json",
   "include": ["**/specs/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,17 @@
   "buildOnSave": false,
   "compileOnSave": false,
   "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2015",
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "target": "es5",
-    "lib": ["es2015", "es2016"],
-    "types": ["chai", "mocha", "node", "sinon"],
-    "jsx": "react"
+    "noEmitOnError": true,
+    "noImplicitAny": false,
+    "sourceMap": true,
+    "inlineSourceMap": false,
+    "inlineSources": true,
+    "lib": ["es2018"],
+    "types": ["chai", "mocha", "node", "sinon"]
   },
-  "exclude": ["dist", ".ng_build", "integration"]
+  "exclude": ["dist", "integration"]
 }


### PR DESCRIPTION
We don't need to trigger on directory removed or renamed as chokidar will fire the changes for each file
