### PR TITLE
feat: build only entrypoints that are effected by the changed

### DIFF
--- a/integration/watch/basic.spec.ts
+++ b/integration/watch/basic.spec.ts
@@ -19,8 +19,8 @@ describe('basic', () => {
   describe('primary entrypoint', () => {
     it("should perform initial compilation when 'watch' is started", () => {
       harness.expectDtsToMatch('public_api', /title = "hello world"/);
-      harness.expectFesm5ToContain('basic', 'title', 'hello world');
-      harness.expectFesm2015ToContain('basic', 'title', 'hello world');
+      harness.expectFesm5ToMatch('basic', /hello world/);
+      harness.expectFesm2015ToMatch('basic', /hello world/);
       harness.expectMetadataToContain('basic', 'metadata.title', 'hello world');
     });
 
@@ -30,8 +30,8 @@ describe('basic', () => {
 
         harness.onComplete(() => {
           harness.expectDtsToMatch('public_api', /title = "foo bar"/);
-          harness.expectFesm5ToContain('basic', 'title', 'foo bar');
-          harness.expectFesm2015ToContain('basic', 'title', 'foo bar');
+          harness.expectFesm5ToMatch('basic', /foo bar/);
+          harness.expectFesm2015ToMatch('basic', /foo bar/);
           harness.expectMetadataToContain('basic', 'metadata.title', 'foo bar');
           done();
         });
@@ -42,8 +42,8 @@ describe('basic', () => {
 
         harness.onComplete(() => {
           harness.expectDtsToMatch('public_api', /title = "foo bar"/);
-          harness.expectFesm5ToContain('basic', 'title', 'foo bar');
-          harness.expectFesm2015ToContain('basic', 'title', 'foo bar');
+          harness.expectFesm5ToMatch('basic', /foo bar/);
+          harness.expectFesm2015ToMatch('basic', /foo bar/);
           harness.expectMetadataToContain('basic', 'metadata.title', 'foo bar');
           done();
         });
@@ -62,8 +62,8 @@ describe('basic', () => {
         harness.copyTestCase('secondary-valid');
 
         harness.onComplete(() => {
-          harness.expectFesm5ToContain('basic-secondary', 'ɵa.decorators[0].args[0].template', 'Hello Angular');
-          harness.expectFesm2015ToContain('basic-secondary', 'ɵa.decorators[0].args[0].template', 'Hello Angular');
+          harness.expectFesm5ToMatch('basic-secondary', /Hello Angular/);
+          harness.expectFesm2015ToMatch('basic-secondary', /Hello Angular/);
           harness.expectMetadataToContain(
             'secondary/basic-secondary',
             'metadata.ɵa.decorators[0].arguments[0].template',

--- a/integration/watch/intra-dependent.spec.ts
+++ b/integration/watch/intra-dependent.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import { TestHarness } from './test-harness';
+
+describe('intra-dependent', () => {
+  const harness = new TestHarness('intra-dependent');
+
+  before(async () => {
+    await harness.initialize();
+  });
+
+  afterEach(() => {
+    harness.reset();
+  });
+
+  after(() => {
+    harness.dispose();
+  });
+
+  it("should perform initial compilation when 'watch' is started", () => {
+    harness.expectDtsToMatch('src/primary.component', /count: number/);
+    harness.expectFesm5ToMatch('intra-dependent-secondary', /count = 100/);
+    harness.expectFesm2015ToMatch('intra-dependent-secondary', /count = 100/);
+  });
+
+  it('should throw error component inputs is changed without updating usages', done => {
+    harness.copyTestCase('invalid-component-property');
+
+    harness.onFailure(error => {
+      expect(error.message).to.match(/Can\'t bind to \'count\' since it isn\'t a known property/);
+      harness.copyTestCase('valid');
+      done();
+    });
+  });
+
+  it('should throw error service method is changed without updating usages', done => {
+    harness.copyTestCase('invalid-service-method');
+
+    harness.onFailure(error => {
+      expect(error.message).to.match(/Property \'initialize\' does not exist on type \'PrimaryAngularService\'/);
+      harness.copyTestCase('valid');
+      done();
+    });
+  });
+
+  it('should only build entrypoints that are dependent on the file changed.', done => {
+    const primaryFesmPath = harness.getFilePath('fesm5/intra-dependent.js');
+    const secondaryFesmPath = harness.getFilePath('fesm5/intra-dependent-secondary.js');
+    const thirdFesmPath = harness.getFilePath('fesm5/intra-dependent-third.js');
+
+    const primaryModifiedTime = fs.statSync(primaryFesmPath).mtimeMs;
+    const secondaryModifiedTime = fs.statSync(secondaryFesmPath).mtimeMs;
+    const thirdModifiedTime = fs.statSync(thirdFesmPath).mtimeMs;
+    harness.copyTestCase('valid');
+
+    harness.onComplete(() => {
+      expect(fs.statSync(primaryFesmPath).mtimeMs).to.greaterThan(primaryModifiedTime);
+      expect(fs.statSync(secondaryFesmPath).mtimeMs).to.greaterThan(secondaryModifiedTime);
+      expect(fs.statSync(thirdFesmPath).mtimeMs).to.equals(thirdModifiedTime);
+      done();
+    });
+  });
+});

--- a/integration/watch/intra-dependent/package.json
+++ b/integration/watch/intra-dependent/package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../src/package.schema.json",
+  "name": "intra-dependent",
+  "description": "A sample library testing Angular Package Format",
+  "version": "1.0.0-pre.0",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "main": "dist/bundles/intra-dependent.umd.js",
+  "peerDependencies": {
+    "@angular/core": "^4.1.2",
+    "@angular/common": "^4.1.2"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
+  }
+}

--- a/integration/watch/intra-dependent/public_api.ts
+++ b/integration/watch/intra-dependent/public_api.ts
@@ -1,0 +1,3 @@
+export { PrimaryAngularModule } from './src/primary.module';
+export { PrimaryAngularComponent } from './src/primary.component';
+export { PrimaryAngularService } from './src/primary.service';

--- a/integration/watch/intra-dependent/secondary/package.json
+++ b/integration/watch/intra-dependent/secondary/package.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../../src/package.schema.json",
+  "description": "A secondary entry point",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
+  }
+}

--- a/integration/watch/intra-dependent/secondary/public_api.ts
+++ b/integration/watch/intra-dependent/secondary/public_api.ts
@@ -1,0 +1,2 @@
+export { SecondaryAngularModule } from './src/secondary.module';
+export { SecondaryAngularComponent } from './src/secondary.component';

--- a/integration/watch/intra-dependent/secondary/src/secondary.component.ts
+++ b/integration/watch/intra-dependent/secondary/src/secondary.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { PrimaryAngularService } from 'intra-dependent';
+
+@Component({
+  selector: 'ng-component-secondary',
+  template: '<ng-component [count]="count"></ng-component>'
+})
+export class SecondaryAngularComponent {
+  count = 100;
+
+  constructor(service: PrimaryAngularService) {
+    service.initialize();
+  }
+}

--- a/integration/watch/intra-dependent/secondary/src/secondary.module.ts
+++ b/integration/watch/intra-dependent/secondary/src/secondary.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SecondaryAngularComponent } from './secondary.component';
+import { PrimaryAngularModule } from 'intra-dependent';
+
+@NgModule({
+  imports: [CommonModule, PrimaryAngularModule],
+  declarations: [SecondaryAngularComponent],
+  exports: [SecondaryAngularComponent]
+})
+export class SecondaryAngularModule {}

--- a/integration/watch/intra-dependent/src/primary.component.ts
+++ b/integration/watch/intra-dependent/src/primary.component.ts
@@ -1,0 +1,9 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ng-component',
+  template: '{{ count }}'
+})
+export class PrimaryAngularComponent {
+  @Input() count: number;
+}

--- a/integration/watch/intra-dependent/src/primary.module.ts
+++ b/integration/watch/intra-dependent/src/primary.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PrimaryAngularComponent } from './primary.component';
+import { PrimaryAngularService } from './primary.service';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [PrimaryAngularComponent],
+  providers: [PrimaryAngularService],
+  exports: [PrimaryAngularComponent]
+})
+export class PrimaryAngularModule {}

--- a/integration/watch/intra-dependent/src/primary.service.ts
+++ b/integration/watch/intra-dependent/src/primary.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class PrimaryAngularService {
+  initialize() {
+    // stub
+  }
+}

--- a/integration/watch/intra-dependent/test_files/invalid-component-property/src/primary.component.ts
+++ b/integration/watch/intra-dependent/test_files/invalid-component-property/src/primary.component.ts
@@ -1,0 +1,9 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ng-component',
+  template: '{{ counter }}'
+})
+export class PrimaryAngularComponent {
+  @Input() counter: string;
+}

--- a/integration/watch/intra-dependent/test_files/invalid-service-method/src/primary.service.ts
+++ b/integration/watch/intra-dependent/test_files/invalid-service-method/src/primary.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class PrimaryAngularService {
+  init() {
+    // stub
+  }
+}

--- a/integration/watch/intra-dependent/test_files/valid/src/primary.component.ts
+++ b/integration/watch/intra-dependent/test_files/valid/src/primary.component.ts
@@ -1,0 +1,9 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ng-component',
+  template: '{{ count }}'
+})
+export class PrimaryAngularComponent {
+  @Input() count: number;
+}

--- a/integration/watch/intra-dependent/test_files/valid/src/primary.service.ts
+++ b/integration/watch/intra-dependent/test_files/valid/src/primary.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class PrimaryAngularService {
+  initialize() {
+    // stub
+  }
+}

--- a/integration/watch/intra-dependent/third/package.json
+++ b/integration/watch/intra-dependent/third/package.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../../src/package.schema.json",
+  "description": "A third entry point",
+  "private": true,
+  "repository": "https://github.com/dherges/ng-packagr.git",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
+  }
+}

--- a/integration/watch/intra-dependent/third/public_api.ts
+++ b/integration/watch/intra-dependent/third/public_api.ts
@@ -1,0 +1,2 @@
+export { ThirdAngularModule } from './src/third.module';
+export { ThirdAngularComponent } from './src/third.component';

--- a/integration/watch/intra-dependent/third/src/third.component.ts
+++ b/integration/watch/intra-dependent/third/src/third.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ng-component-third',
+  template: 'Hello world!'
+})
+export class ThirdAngularComponent {}

--- a/integration/watch/intra-dependent/third/src/third.module.ts
+++ b/integration/watch/intra-dependent/third/src/third.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ThirdAngularComponent } from './third.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [ThirdAngularComponent],
+  exports: [ThirdAngularComponent]
+})
+export class ThirdAngularModule {}

--- a/integration/watch/test-harness.ts
+++ b/integration/watch/test-harness.ts
@@ -13,27 +13,35 @@ import { tap } from 'rxjs/operators';
 export class TestHarness {
   private completeHandler = () => undefined;
 
-  private tmpPath = path.join(__dirname, '.tmp', this.testName);
+  private harnessTempDir = path.join(__dirname, '.tmp');
+  private testTempPath = path.join(this.harnessTempDir, this.testName);
   private testSrc = path.join(__dirname, this.testName);
+  private testDistPath = path.join(this.testTempPath, 'dist');
   private ngPackagr$$: Subscription;
+  private loggerStubs: { [key: string]: sinon.SinonStub } = {};
 
   constructor(private testName: string) {}
 
   initialize(): Promise<void> {
     // the below is done in order to avoid poluting the test reporter with build logs
-    sinon.stub(log, 'msg');
-    sinon.stub(log, 'info');
-    sinon.stub(log, 'debug');
-    sinon.stub(log, 'success');
-    sinon.stub(log, 'warn');
+    for (const key in log) {
+      if (log.hasOwnProperty(key)) {
+        this.loggerStubs[key] = sinon.stub(log, key as keyof typeof log);
+      }
+    }
 
     this.emptyTestDirectory();
-    fs.copySync(this.testSrc, this.tmpPath);
+    fs.copySync(this.testSrc, this.testTempPath);
+
     return this.setUpNgPackagr();
   }
 
   dispose(): void {
     this.reset();
+
+    for (const key in this.loggerStubs) {
+      this.loggerStubs[key].restore();
+    }
 
     if (this.ngPackagr$$) {
       this.ngPackagr$$.unsubscribe();
@@ -43,11 +51,12 @@ export class TestHarness {
   }
 
   reset(): void {
+    this.loggerStubs['error'].resetBehavior();
     this.completeHandler = () => undefined;
   }
 
   readFileSync(filePath: string, isJson = false): string | object {
-    const file = path.join(this.tmpPath, 'dist', filePath);
+    const file = path.join(this.testDistPath, filePath);
     return isJson ? fs.readJsonSync(file) : fs.readFileSync(file, { encoding: 'utf-8' });
   }
 
@@ -55,15 +64,15 @@ export class TestHarness {
    * Copy a test case to it's temporary destination immediately.
    */
   copyTestCase(caseName: string) {
-    fs.copySync(path.join(this.testSrc, 'test_files', caseName), this.tmpPath);
+    fs.copySync(path.join(this.testSrc, 'test_files', caseName), this.testTempPath);
   }
 
-  expectFesm5ToContain(fileName: string, path: string, value: any): Chai.Assertion {
-    return expect(this.requireNoCache(`fesm5/${fileName}.js`)).to.have.nested.property(path, value);
+  expectFesm5ToMatch(fileName: string, regexp: RegExp): Chai.Assertion {
+    return expect(this.readFileSync(`fesm5/${fileName}.js`)).to.match(regexp);
   }
 
-  expectFesm2015ToContain(fileName: string, path: string, value: any): Chai.Assertion {
-    return expect(this.requireNoCache(`fesm2015/${fileName}.js`)).to.have.nested.property(path, value);
+  expectFesm2015ToMatch(fileName: string, regexp: RegExp): Chai.Assertion {
+    return expect(this.readFileSync(`fesm2015/${fileName}.js`)).to.match(regexp);
   }
 
   expectDtsToMatch(fileName: string, regexp: RegExp): Chai.Assertion {
@@ -86,20 +95,24 @@ export class TestHarness {
    * Gets invoked when a compilation error occuries.
    */
   onFailure(done: (error: Error) => void): void {
-    sinon.stub(log, 'error').callsFake(done);
+    this.loggerStubs['error'].callsFake(done);
   }
 
   /**
    * Remove the entire directory for the current test case.
    */
   emptyTestDirectory(): void {
-    fs.emptyDirSync(this.tmpPath);
+    fs.emptyDirSync(this.testTempPath);
+  }
+
+  getFilePath(filePath: string): string {
+    return path.join(this.testDistPath, filePath);
   }
 
   private setUpNgPackagr(): Promise<void> {
     return new Promise(resolve => {
       this.ngPackagr$$ = ngPackagr()
-        .forProject(path.join(this.tmpPath, 'package.json'))
+        .forProject(path.join(this.testTempPath, 'package.json'))
         .watch()
         .pipe(
           tap(() => resolve()), // we are only interested when in the first builds, that's why we are resolving it
@@ -107,15 +120,5 @@ export class TestHarness {
         )
         .subscribe();
     });
-  }
-
-  private requireNoCache(modulePath: string): any {
-    const moduleFile = this.buildFilePath(modulePath);
-    delete require.cache[path.resolve(moduleFile)];
-    return require(moduleFile);
-  }
-
-  private buildFilePath(filePath: string): string {
-    return path.join(this.tmpPath, 'dist', filePath);
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "integration:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --require ts-node/register \"integration/samples/*/specs/**/*.ts\"",
     "integration:consumers": "integration/consumers.sh",
     "integration:consumers:ngc": "ngc -p integration/consumers/tsc/tsconfig.json",
-    "integration:watch:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --timeout 20000 --require ts-node/register \"integration/watch/*.spec.ts\"",
+    "integration:watch:specs": "cross-env TS_NODE_PROJECT=integration/tsconfig.specs.json mocha --timeout 25000 --require ts-node/register \"integration/watch/*.spec.ts\"",
     "test:specs": "cross-env TS_NODE_PROJECT=src/tsconfig.specs.json mocha --require ts-node/register \"src/**/*.spec.ts\"",
     "test": "yarn build && yarn test:specs && yarn integration:samples && yarn integration:specs && yarn integration:watch:specs && yarn integration:consumers",
     "commitmsg": "commitlint -e",

--- a/src/lib/file/file-cache.ts
+++ b/src/lib/file/file-cache.ts
@@ -5,6 +5,7 @@ export interface CacheEntry {
   exists?: boolean;
   sourceFile?: ts.SourceFile;
   content?: string;
+  declarationFileName?: string;
 }
 
 export class FileCache {
@@ -31,6 +32,10 @@ export class FileCache {
 
   has(fileName: string): boolean {
     return this.cache.has(this.normalizeKey(fileName));
+  }
+
+  get(fileName: string): CacheEntry | undefined {
+    return this.cache.get(this.normalizeKey(fileName));
   }
 
   getOrCreate(fileName: string): CacheEntry {

--- a/src/lib/ts/cache-compiler-host.ts
+++ b/src/lib/ts/cache-compiler-host.ts
@@ -33,6 +33,25 @@ export function cacheCompilerHost(
       return cache.sourceFile;
     },
 
+    writeFile: (
+      fileName: string,
+      data: string,
+      writeByteOrderMark: boolean,
+      onError?: (message: string) => void,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>
+    ) => {
+      if (fileName.endsWith('.d.ts')) {
+        sourceFiles.forEach(source => {
+          const cache = sourcesFileCache.getOrCreate(source.fileName);
+          if (!cache.declarationFileName) {
+            cache.declarationFileName = ensureUnixPath(fileName);
+          }
+        });
+      }
+
+      compilerHost.writeFile.call(this, fileName, data, writeByteOrderMark, onError, sourceFiles);
+    },
+
     readFile: (fileName: string) => {
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.content === undefined) {


### PR DESCRIPTION
When the public API that is consumed from another entrypoint changes, the updated API changes are now reflected in the secondary entrypoint. Also, now only entrypoints that are effected by this file change will be marked as `dirty` and therefore scheduled to be built.

Relates: #974