### PR TITLE
fix: don't exclude `node_modules` from watch

### DIFF
--- a/src/lib/file/file-watcher.ts
+++ b/src/lib/file/file-watcher.ts
@@ -18,7 +18,7 @@ export function createFileWatch(
 
   const watch = chokidar.watch(projectPath, {
     ignoreInitial: true,
-    ignored: [...ignoredPaths, /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json)|(node_modules)/],
+    ignored: [...ignoredPaths, /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json)/],
     persistent: true
   });
 


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[x] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description

In some cases consumers which have a seperate watch running that will update `node_modules` due to an `npm link`. We shall not exclude `node_modules` from being watched for this usecase.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
