### PR TITLE
fix: copy nested triple slash referenced typings to correct path (v3)

### DIFF
--- a/integration/samples/typings/specs/typings.ts
+++ b/integration/samples/typings/specs/typings.ts
@@ -29,4 +29,15 @@ describe(`sample-typings`, () => {
       expect(CHALK_DTS).to.be.ok;
     });
   });
+
+  describe(`src/nested/reference/mocked.d.ts`, () => {
+    let MOCKED_DTS;
+    before(() => {
+      MOCKED_DTS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'nested/reference/mocked.d.ts'), 'utf-8');
+    });
+
+    it(`should exist in 'dist' folder`, () => {
+      expect(MOCKED_DTS).to.be.ok;
+    });
+  });
 });

--- a/integration/samples/typings/src/nested/reference/index.ts
+++ b/integration/samples/typings/src/nested/reference/index.ts
@@ -1,0 +1,3 @@
+/// <reference path="./mocked.d.ts" />
+
+export const faz: Mocked = { foo: 'bar' };

--- a/integration/samples/typings/src/nested/reference/mocked.d.ts
+++ b/integration/samples/typings/src/nested/reference/mocked.d.ts
@@ -1,0 +1,3 @@
+interface Mocked {
+  foo: string;
+}

--- a/integration/samples/typings/src/public_api.ts
+++ b/integration/samples/typings/src/public_api.ts
@@ -1,1 +1,2 @@
 export * from './validator';
+export * from './nested/reference/index';

--- a/src/lib/ng-v5/entry-point/write-package.transform.ts
+++ b/src/lib/ng-v5/entry-point/write-package.transform.ts
@@ -8,7 +8,6 @@ import { rimraf } from '../../util/rimraf';
 import * as log from '../../util/log';
 import { globFiles } from '../../util/glob';
 import { isEntryPointInProgress, EntryPointNode, isEntryPointDirty } from '../nodes';
-import { copyFiles } from '../../util/copy';
 
 export const writePackageTransform: Transform = transformFromPromise(async graph => {
   const entryPoint = graph.find(isEntryPointInProgress()) as EntryPointNode;
@@ -23,7 +22,15 @@ export const writePackageTransform: Transform = transformFromPromise(async graph
     ignore: ['**/node_modules/**', `${ngPackage.dest}/**`]
   });
 
-  await copyFiles(declarationFiles, path.dirname(destinationFiles.declarations));
+  if (declarationFiles.length) {
+    await Promise.all(
+      declarationFiles.map(value => {
+        const relativePath = path.relative(ngEntryPoint.entryFilePath, value);
+        const destination = path.resolve(destinationFiles.declarations, relativePath);
+        return fs.copy(value, destination);
+      })
+    );
+  }
 
   // 6. WRITE PACKAGE.JSON
   log.info('Writing package metadata');


### PR DESCRIPTION
Backporting https://github.com/dherges/ng-packagr/pull/1009 to v3