### PR TITLE
fix: copy nested triple slash referenced typings to correct path (v4)

### DIFF
--- a/integration/samples/typings/specs/typings.ts
+++ b/integration/samples/typings/specs/typings.ts
@@ -29,4 +29,15 @@ describe(`sample-typings`, () => {
       expect(CHALK_DTS).to.be.ok;
     });
   });
+
+  describe(`src/nested/reference/mocked.d.ts`, () => {
+    let MOCKED_DTS;
+    before(() => {
+      MOCKED_DTS = fs.readFileSync(path.resolve(__dirname, '..', 'dist', 'nested/reference/mocked.d.ts'), 'utf-8');
+    });
+
+    it(`should exist in 'dist' folder`, () => {
+      expect(MOCKED_DTS).to.be.ok;
+    });
+  });
 });

--- a/integration/samples/typings/src/nested/reference/index.ts
+++ b/integration/samples/typings/src/nested/reference/index.ts
@@ -1,0 +1,3 @@
+/// <reference path="./mocked.d.ts" />
+
+export const faz: Mocked = { foo: 'bar' };

--- a/integration/samples/typings/src/nested/reference/mocked.d.ts
+++ b/integration/samples/typings/src/nested/reference/mocked.d.ts
@@ -1,0 +1,3 @@
+interface Mocked {
+  foo: string;
+}

--- a/integration/samples/typings/src/public_api.ts
+++ b/integration/samples/typings/src/public_api.ts
@@ -1,1 +1,2 @@
 export * from './validator';
+export * from './nested/reference/index';


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [] Tests for the changes have been added


## Description
At the moment, typings reference with the triple slash reference are copied to the root dist path, and is causing the folder structure to be lost.


Closes: #1007

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
