### PR TITLE
perf: analyse sources only for dirty entrypoints

### DIFF
--- a/src/lib/ng-v5/init/analyse-sources.transform.ts
+++ b/src/lib/ng-v5/init/analyse-sources.transform.ts
@@ -10,8 +10,7 @@ import { unique, flatten } from '../../util/array';
 
 export const analyseSourcesTransform: Transform = pipe(
   map(graph => {
-    const entryPoints = graph.filter(isEntryPoint) as EntryPointNode[];
-
+    const entryPoints = graph.filter(x => isEntryPoint(x) && x.state !== 'done') as EntryPointNode[];
     for (let entryPoint of entryPoints) {
       analyseEntryPoint(entryPoint, entryPoints);
     }


### PR DESCRIPTION

## I'm submitting a...

```
[ ] Bug Fix
[ ] Feature
[x] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added


## Description

At the moment, on incremental builds this is being done for all entrypoints even once that are not marked dirty.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
