### PR TITLE
fix: add `enableResourceInlining` by default

### DIFF
--- a/src/lib/ts/tsconfig.ts
+++ b/src/lib/ts/tsconfig.ts
@@ -77,7 +77,8 @@ export const initializeTsConfig = (defaultTsConfig: TsConfig, entryPoints: Entry
         // setting the below here because these are a must have with these valus
         inlineSourceMap: true,
         sourceMap: false,
-        sourceRoot: `ng://${entryPoint.moduleId}`
+        sourceRoot: `ng://${entryPoint.moduleId}`,
+        enableResourceInlining: true
       }
     };
 


### PR DESCRIPTION
Having this off might break a lot of users that are using Angular-CLI as they might skip reading the changelog and the resulting error message is a bit ambiguous.

Closes #976

//cc @filipesilva 