### PR TITLE
fix: add fallback for `sources` when re-wiring sourcemaps

### DIFF
--- a/integration/samples/core/specs/sourcemaps.ts
+++ b/integration/samples/core/specs/sourcemaps.ts
@@ -37,6 +37,10 @@ describe(`@sample/core`, () => {
       expect(sourceMap).to.be.ok;
     });
 
+    it(`should not have any 'null' in sources`, () => {
+      expect(sourceMap.sources.includes(null)).to.be.false;
+    });
+
     it(`should have 'sources' and 'sourcesContent' property`, () => {
       expect(sourceMap.sources).to.be.an('array').that.is.not.empty;
       expect(sourceMap.sourcesContent).to.be.an('array').that.is.not.empty;
@@ -45,7 +49,7 @@ describe(`@sample/core`, () => {
 
     it(`should reference each 'sources' path with a common prefix`, () => {
       const everyUeveryMe = (sourceMap.sources as string[])
-        .filter(fileName => fileName !== 'null')
+        .filter(fileName => fileName !== 'null' && !fileName.startsWith('node_modules'))
         .every(fileName => fileName.startsWith('ng://@sample/core') && fileName.endsWith('.ts'));
       expect(everyUeveryMe).to.be.true;
     });

--- a/src/lib/flatten/rollup.ts
+++ b/src/lib/flatten/rollup.ts
@@ -79,6 +79,8 @@ export async function rollupBundleFile(opts: RollupOptions): Promise<void[]> {
       return `${opts.sourceRoot}${sourcePath.substr(sourcePath.indexOf(mapRootUrl) + mapRootUrl.length)}`;
     } else if (sourcePath.indexOf(opts.sourceRoot) > 0) {
       return sourcePath.substr(sourcePath.indexOf(mapRootUrl));
+    } else {
+      return sourcePath;
     }
   });
 


### PR DESCRIPTION
## I'm submitting a...

```
[x] Bug Fix
[ ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [X] Tests for the changes have been added


## Description
In some cases when a `null` is returned this will cause webpack loader to fail as there are no null checks.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

//cc @stephenlautier